### PR TITLE
Allow other SDM realms in pubsub.

### DIFF
--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 EXPECTED_SUBSCRIBER_REGEXP = re.compile("projects/.*/subscriptions/.*")
 
 # Used to catch a topic misconfiguration
-EXPECTED_TOPIC_REGEXP = re.compile("projects/sdm-prod/.*")
+EXPECTED_TOPIC_REGEXP = re.compile("projects/sdm-[a-z]+/topics/.*")
 
 
 class AbstractSusbcriberFactory(ABC):


### PR DESCRIPTION
Loosen the check done by google_nest_subscriber to allow any SDM pubsub topic, not just `sdm-prod` topics. This will allow testers to use other SDM environments as necessary.