### PR TITLE
Return only active or fetched events

### DIFF
--- a/google_nest_sdm/event.py
+++ b/google_nest_sdm/event.py
@@ -94,6 +94,12 @@ class ImageEventBase(ABC):
         """Timestamp when the message expires."""
         return self._timestamp + datetime.timedelta(seconds=EVENT_IMAGE_EXPIRE_SECS)
 
+    @property
+    def is_expired(self) -> bool:
+        """Return true if the event expiration has passed."""
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        return self.expires_at < now
+
 
 @EVENT_MAP.register()
 class CameraMotionEvent(ImageEventBase):
@@ -178,9 +184,7 @@ class EventTrait(ABC):
         """Any current active events."""
         if not self._last_event:
             return None
-        if self._last_event.expires_at < datetime.datetime.now(
-            tz=datetime.timezone.utc
-        ):
+        if self._last_event.is_expired:
             return None
         return self._last_event
 

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -155,6 +155,11 @@ class EventMediaManager:
         """Return revent events."""
         result = list(self._event_data.values())
         result.sort(key=lambda x: x.timestamp, reverse=True)
+        # If event fetching is on, then return all the events we have.
+        # Otherwise, only return events that have not expired since there
+        # is no chance we can actually fetch the media.
+        if not self._cache_policy.fetch:
+            result = list(filter(lambda x: not x.is_expired, result))
         return result
 
     async def async_handle_events(self, event_message: EventMessage) -> None:

--- a/pyproject.tlm
+++ b/pyproject.tlm
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 88


### PR DESCRIPTION
Return only events that have fetched media or are still active and fetch media
may be possibly fetched, to avoid broken thumbnails for expired images.