### PR TITLE
Internal event media refactoring to support persistence

### DIFF
--- a/google_nest_sdm/device.py
+++ b/google_nest_sdm/device.py
@@ -58,7 +58,8 @@ class Device:
             self._relations[relation[PARENT]] = relation[DISPLAYNAME]
         self._callbacks: List[Callable[[EventMessage], Awaitable[None]]] = []
         event_trait_map = _MakeEventTraitMap(self._traits)
-        self._event_media_manager = EventMediaManager(event_trait_map)
+
+        self._event_media_manager = EventMediaManager(self.name, event_trait_map)
 
     @staticmethod
     def MakeDevice(raw_data: Mapping[str, Any], auth: AbstractAuth) -> Device:

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import datetime
+import json
 from typing import Any, Callable, Dict, Optional
 
 from google_nest_sdm.event import (
@@ -356,6 +359,60 @@ def test_camera_clip_preview_event(
     assert "sdm.devices.events.CameraClipPreview.ClipPreview" in events
     e = events["sdm.devices.events.CameraClipPreview.ClipPreview"]
     assert isinstance(e, CameraClipPreviewEvent)
+    assert "CjY5Y3VKaTZwR3o4Y19YbTVfMF..." == e.event_session_id
+    assert ts == e.timestamp
+    assert (
+        "1cd28a21db0705a03f612d1df956444094a8c85a75fd35dfd277a81b5a9ad2a8c18"
+        "2a9a7decb2936664d6e1344915850a31fc3c828c3813765d1c73be1e958f3" == e.event_id
+    )
+    assert "https://previewUrl/..." == e.preview_url
+    expire_ts = datetime.datetime(2019, 1, 1, 0, 15, 1, tzinfo=datetime.timezone.utc)
+    assert expire_ts == e.expires_at
+
+
+def test_event_serialization(
+    fake_event_message: Callable[[Dict[str, Any]], EventMessage]
+) -> None:
+    event = fake_event_message(
+        {
+            "eventId": "201fcd21-967a-4f82-8082-5073bd09d31f",
+            "timestamp": "2019-01-01T00:00:01Z",
+            "resourceUpdate": {
+                "name": "enterprises/project-id/devices/device-id",
+                "events": {
+                    "sdm.devices.events.CameraClipPreview.ClipPreview": {
+                        "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                        "previewUrl": "https://previewUrl/...",
+                    }
+                },
+            },
+            "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+        }
+    )
+    assert "201fcd21-967a-4f82-8082-5073bd09d31f" == event.event_id
+    ts = datetime.datetime(2019, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc)
+
+    assert ts == event.timestamp
+    assert "enterprises/project-id/devices/device-id" == event.resource_update_name
+
+    events: Optional[Dict[str, ImageEventBase]] = event.resource_update_events
+    assert events is not None
+    assert "sdm.devices.events.CameraClipPreview.ClipPreview" in events
+    e: ImageEventBase | None = events[
+        "sdm.devices.events.CameraClipPreview.ClipPreview"
+    ]
+    assert e
+    assert isinstance(e, CameraClipPreviewEvent)
+
+    # Serialize the event then unserialize and veirfy everything is still correct
+    data = e.as_dict()
+    dump = json.dumps(data)
+    data = json.loads(dump)
+
+    e = ImageEventBase.from_dict(data)
+    assert e
+    assert isinstance(e, CameraClipPreviewEvent)
+
     assert "CjY5Y3VKaTZwR3o4Y19YbTVfMF..." == e.event_session_id
     assert ts == e.timestamp
     assert (

--- a/tests/google_nest_api_test.py
+++ b/tests/google_nest_api_test.py
@@ -1277,7 +1277,7 @@ async def test_event_manager_image(
     assert event_media.media.contents == b"image-bytes-2"
     assert event_media.media.event_image_type.content_type == "image/jpeg"
 
-    assert len(list(event_media_manager.events)) == 2
+    assert len(list(await event_media_manager.async_events())) == 2
 
 
 async def test_event_manager_prefetch_image(
@@ -1358,7 +1358,7 @@ async def test_event_manager_prefetch_image(
     assert event_media.media.contents == b"image-bytes-1"
     assert event_media.media.event_image_type.content_type == "image/jpeg"
 
-    assert len(list(event_media_manager.events)) == 1
+    assert len(list(await event_media_manager.async_events())) == 1
 
 
 async def test_event_manager_event_expiration(
@@ -1451,4 +1451,4 @@ async def test_event_manager_event_expiration(
     )
 
     event_media_manager = device.event_media_manager
-    assert len(list(event_media_manager.events)) == 2
+    assert len(list(await event_media_manager.async_events())) == 2


### PR DESCRIPTION
Add additional interfaces to support persistence, which is planned to
support writing to disk by Home Assistant.

Additional work needed to:
- allow a different interface to be provided
- fix performance