### PR TITLE
Exclude command line tools from code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 source=google_nest_sdm
+
+omit =
+  google_nest_sdm/google_nest.py

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ $ pip3 install -r requirements.txt
 # Running tests
 $ pytest
 
+# Running tests w/ Code Coverage
+$ pytest --cov=google_nest_sdm tests/ --cov-report=term-missing
+
 # Formatting and linting
 $ pre-commit run --all-files
 ```


### PR DESCRIPTION
Update the coverage configuration to exclude command line tool from test coverage. Also add documentation about test runs with code coverage.