### PR TITLE
Update renovate configurations for aiothttp

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -46,6 +46,7 @@
       ],
       "groupSlug": "aiohttp",
       "matchUpdateTypes": ["minor", "patch", "major"],
+      "separateMajorReleases": false,
     },
     {
       "description": "Minor updates are automatic",


### PR DESCRIPTION
Don't separate major and minor aiohttp releases so that everything is grouped together and has a better change to get updated at the same time without conflicting package versions.