### PR TITLE
Add shared CachePolicy at Subscriber level

### DIFF
--- a/google_nest_sdm/device_manager.py
+++ b/google_nest_sdm/device_manager.py
@@ -1,5 +1,7 @@
 """Device Manager keeps track of the current state of all devices."""
 
+from __future__ import annotations
+
 from typing import Dict, Optional
 
 from .device import Device
@@ -11,11 +13,11 @@ from .structure import InfoTrait, RoomInfoTrait, Structure
 class DeviceManager:
     """DeviceManager holds current state of all devices."""
 
-    def __init__(self) -> None:
+    def __init__(self, cache_policy: CachePolicy | None = None) -> None:
         """Initialize DeviceManager."""
         self._devices: Dict[str, Device] = {}
         self._structures: Dict[str, Structure] = {}
-        self._cache_policy = CachePolicy()
+        self._cache_policy = cache_policy if cache_policy else CachePolicy()
 
     @property
     def devices(self) -> Dict[str, Device]:

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -18,6 +18,7 @@ from google.protobuf.duration_pb2 import Duration
 from .auth import AbstractAuth
 from .device_manager import DeviceManager
 from .event import EventMessage
+from .event_media import CachePolicy
 from .exceptions import AuthException, ConfigurationException, SubscriberException
 from .google_nest_api import GoogleNestAPI
 
@@ -275,6 +276,7 @@ class GoogleNestSubscriber:
         self._watchdog_restart_delay_min_seconds = watchdog_restart_delay_min_seconds
         self._watchdog_restart_delay_seconds = watchdog_restart_delay_min_seconds
         self._watchdog_task: Optional[asyncio.Task] = None
+        self._cache_policy = CachePolicy()
 
     @property
     def subscriber_id(self) -> str:
@@ -407,6 +409,11 @@ class GoogleNestSubscriber:
         if self._subscriber_future:
             self._subscriber_future.cancel()
 
+    @property
+    def cache_policy(self) -> CachePolicy:
+        """Return cache policy shared by device EventMediaManager objects."""
+        return self._cache_policy
+
     async def async_get_device_manager(self) -> DeviceManager:
         """Return the DeviceManger with the current state of devices."""
         if not self._device_manager_task:
@@ -418,7 +425,7 @@ class GoogleNestSubscriber:
 
     async def _async_create_device_manager(self) -> DeviceManager:
         """Create a DeviceManager, populated with initial state."""
-        device_manager = DeviceManager()
+        device_manager = DeviceManager(self._cache_policy)
         structures = await self._api.async_get_structures()
         for structure in structures:
             device_manager.add_structure(structure)

--- a/tests/google_nest_subscriber_test.py
+++ b/tests/google_nest_subscriber_test.py
@@ -230,6 +230,7 @@ async def test_subscribe_update_trait(
     )
 
     subscriber = await subscriber_client()
+    subscriber.cache_policy.event_cache_size = 5
     await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
     devices = device_manager.devices


### PR DESCRIPTION
Expose the shared cache policy at the subscriber level so that it
can be updated before starting the subscriber and events arrive.