### PR TITLE
Only delete media if it exists

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -163,7 +163,8 @@ class InMemoryEventMediaStore(EventMediaStore):
 
     async def async_remove_media(self, media_key: str) -> None:
         """Remove media content."""
-        del self._media[media_key]
+        if media_key in self._media:
+            del self._media[media_key]
 
 
 class EventMediaModelItem:
@@ -340,6 +341,7 @@ class EventMediaManager:
 
             # Prefetch media, otherwise we may
             if self._cache_policy.fetch:
+                _LOGGER.debug("Fetching media for event_id=%s", event.event_id)
                 try:
                     await self.get_media(event.event_id)
                 except GoogleNestException as err:


### PR DESCRIPTION
Fix regression where media key may not actually exist and attempts to delete it fail. It's ok for this to be best effort as the media is not required to exist.