### PR TITLE
Skip fetching images that are expired

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -339,6 +339,10 @@ class EventMediaManager:
                     await self._cache_policy.store.async_remove_media(item.media_key)
             await self._async_update(event_data)
 
+            # We can't fetch media for expired events
+            if event.is_expired:
+                continue
+
             # Prefetch media, otherwise we may
             if self._cache_policy.fetch:
                 _LOGGER.debug("Fetching media for event_id=%s", event.event_id)


### PR DESCRIPTION
Don't fetch an image from the server if the image is already expired. This
helps avoid unnecessary error messages on startup if there are old messages
in the pubsub backlog.

The images are still preserved in the queue, however.