### PR TITLE
Group camera clip events using sessions to improve battery camera events

### DIFF
--- a/google_nest_sdm/device.py
+++ b/google_nest_sdm/device.py
@@ -70,6 +70,18 @@ class Device:
         cmd = Command(device_id, auth)
         traits = raw_data.get(DEVICE_TRAITS, {})
         traits_dict = BuildTraits(traits, cmd, raw_data.get(DEVICE_TYPE))
+
+        # Hack to wire up camera traits to the event image generator
+        event_image_trait: camera_traits.EventImageCreator | None = None
+        if camera_traits.CameraEventImageTrait.NAME in traits_dict:
+            event_image_trait = traits_dict[camera_traits.CameraEventImageTrait.NAME]
+        elif camera_traits.CameraClipPreviewTrait.NAME in traits_dict:
+            event_image_trait = traits_dict[camera_traits.CameraClipPreviewTrait.NAME]
+        if event_image_trait:
+            for trait_class in traits_dict.values():
+                if hasattr(trait_class, "event_image_creator"):
+                    trait_class.event_image_creator = event_image_trait
+
         return Device(raw_data, traits_dict)
 
     @property

--- a/google_nest_sdm/doorbell_traits.py
+++ b/google_nest_sdm/doorbell_traits.py
@@ -1,10 +1,15 @@
 """Traits belonging to doorbell devices."""
 
+from __future__ import annotations
+
+import logging
 from typing import Any, Mapping, Optional
 
-from .camera_traits import CameraEventImageTrait, EventImage, EventImageGenerator
+from .camera_traits import EventImage, EventImageCreator, EventImageGenerator
 from .event import DoorbellChimeEvent, ImageEventBase
 from .traits import TRAIT_MAP, Command
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @TRAIT_MAP.register()
@@ -14,16 +19,19 @@ class DoorbellChimeTrait(EventImageGenerator):
     NAME = "sdm.devices.traits.DoorbellChime"
     EVENT_NAME = DoorbellChimeEvent.NAME
     event_type = EVENT_NAME
+    event_image_creator: EventImageCreator | None = None
 
     def __init__(self, data: Mapping[str, Any], cmd: Command):
         """Initialize DoorbellChime."""
         super().__init__()
         self._data = data
-        self._event_image = CameraEventImageTrait({}, cmd)
 
     async def generate_event_image(self, event: ImageEventBase) -> Optional[EventImage]:
         """Provide a URL to download a camera image from the active event."""
+        _LOGGER.debug("Generating image for event")
         if not isinstance(event, DoorbellChimeEvent):
             return None
         assert event.event_id
-        return await self._event_image.generate_image(event.event_id)
+        if not self.event_image_creator:
+            raise ValueError("Camera does not have trait to fetch snapshots")
+        return await self.event_image_creator.generate_event_image(event)

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -395,9 +395,18 @@ class EventMediaManager:
         _LOGGER.debug("Event Update %s", event_sessions.keys())
 
         # Notify traits to cache events
-        for event_dict in event_sessions.values():
+        pairs = list(event_sessions.items())
+        for event_session_id, event_dict in pairs:
+            supported = False
             for event_name, event in event_dict.items():
-                self._event_trait_map[event_name].handle_event(event)
+                if not (trait := self._event_trait_map.get(event_name)):
+                    continue
+                supported = True
+                trait.handle_event(event)
+
+            # Skip any entirely unsupported events
+            if not supported:
+                del event_sessions[event_session_id]
 
         # Update interal event media representation
         for event_session_id, event_dict in event_sessions.items():

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -10,12 +10,27 @@ from collections.abc import Iterable
 from typing import Any, Dict, Optional
 
 from .camera_traits import EventImageGenerator, EventImageType
-from .event import EventMessage, ImageEventBase
+from .event import (
+    CameraMotionEvent,
+    CameraPersonEvent,
+    CameraSoundEvent,
+    DoorbellChimeEvent,
+    EventMessage,
+    ImageEventBase,
+)
 from .exceptions import GoogleNestException
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_CACHE_SIZE = 2
+
+# Events are collapsed in the order shown here
+VISIBLE_EVENTS = [
+    DoorbellChimeEvent.NAME,
+    CameraPersonEvent.NAME,
+    CameraMotionEvent.NAME,
+    CameraSoundEvent.NAME,
+]
 
 
 class CachePolicy:
@@ -81,20 +96,20 @@ class EventMedia:
 
     def __init__(
         self,
-        event_id: str,
+        event_session_id: str,
         event_type: str,
         event_timestamp: datetime.datetime,
         media: Media,
     ) -> None:
-        self._event_id = event_id
+        self._event_session_id = event_session_id
         self._event_type = event_type
         self._event_timestamp = event_timestamp
         self._media = media
 
     @property
-    def event_id(self) -> str:
+    def event_session_id(self) -> str:
         """Return the event id."""
-        return self._event_id
+        return self._event_session_id
 
     @property
     def event_type(self) -> str:
@@ -151,7 +166,7 @@ class InMemoryEventMediaStore(EventMediaStore):
     def get_media_key(self, device_id: str, event: ImageEventBase) -> str:
         """Return the media key to use for the device and event."""
         suffix = "jpg" if event.event_image_type == EventImageType.IMAGE else "mp4"
-        return f"{device_id}_{event.timestamp}_{event.event_id}.{suffix}"
+        return f"{device_id}_{event.timestamp}_{event.event_session_id}.{suffix}"
 
     async def async_load_media(self, media_key: str) -> bytes | None:
         """Load media content."""
@@ -170,20 +185,49 @@ class InMemoryEventMediaStore(EventMediaStore):
 class EventMediaModelItem:
     """Structure used to persist the event in EventMediaStore."""
 
-    def __init__(self, event: ImageEventBase, media_key: str | None = None) -> None:
+    def __init__(
+        self,
+        event_session_id: str,
+        events: dict[str, ImageEventBase],
+        media_key: str | None = None,
+    ) -> None:
         """Initialize EventMediaModelItem."""
-        self._event = event
+        self._event_session_id = event_session_id
+        self._events = events
         self._media_key = media_key
 
     @staticmethod
-    def from_dict(data: dict[str, Any]) -> EventMediaModelItem | None:
-        if not (event := ImageEventBase.from_dict(data["event"])):
-            return None
-        return EventMediaModelItem(event, data.get("media_key"))
+    def from_dict(data: dict[str, Any]) -> EventMediaModelItem:
+        """Read from serialized dictionary."""
+        events: dict[str, ImageEventBase] = {}
+        input_events = data.get("events", {})
+        for (event_type, event_data) in input_events.items():
+            if not (event := ImageEventBase.from_dict(event_data)):
+                continue
+            events[event_type] = event
+        # Link events to other events in the session
+        for event in events.values():
+            event.session_events = list(events.values())
+        return EventMediaModelItem(
+            data["event_session_id"], events, data.get("media_key")
+        )
 
     @property
-    def event(self) -> ImageEventBase:
-        return self._event
+    def event_session_id(self) -> str:
+        return self._event_session_id
+
+    @property
+    def visible_event(self) -> ImageEventBase | None:
+        """Get the primary visible event for this item."""
+        for event_type in VISIBLE_EVENTS:
+            if event := self._events.get(event_type):
+                return event
+        return None
+
+    @property
+    def events(self) -> dict[str, ImageEventBase]:
+        """Return all associated events with this record."""
+        return self._events
 
     @property
     def media_key(self) -> str | None:
@@ -195,26 +239,32 @@ class EventMediaModelItem:
         self._media_key = value
 
     def get_media(self, content: bytes) -> Media:
-        return Media(content, self.event.event_image_type)
+        assert self.visible_event
+        return Media(content, self.visible_event.event_image_type)
 
     def get_event_media(self, content: bytes) -> EventMedia:
+        assert self.visible_event
         return EventMedia(
-            self.event.event_id,
-            self.event.event_type,
-            self.event.timestamp,
+            self.visible_event.event_session_id,
+            self.visible_event.event_type,
+            self.visible_event.timestamp,
             self.get_media(content),
         )
 
     def as_dict(self) -> dict[str, Any]:
-        result: dict[str, Any] = {"event": self._event.as_dict()}
+        """Return a EventMediaModelItem as a serializable dict."""
+        result: dict[str, Any] = {
+            "event_session_id": self._event_session_id,
+            "events": dict((k, v.as_dict()) for k, v in self._events.items()),
+        }
         if self._media_key:
             result["media_key"] = self._media_key
         return result
 
     def __repr__(self) -> str:
         return (
-            "<EventMediaModelItem event="
-            + str(self._event)
+            "<EventMediaModelItem events="
+            + str(self._events)
             + " media_key="
             + str(self._media_key)
             + ">"
@@ -250,27 +300,28 @@ class EventMediaManager:
             device_data = store_data.get(self._device_id, [])
             for item_data in device_data:
                 item = EventMediaModelItem.from_dict(item_data)
-                if not item:
-                    continue
-                event_data[item.event.event_id] = item
+                event_data[item.event_session_id] = item
         return event_data
 
     async def _async_update(self, event_data: dict[str, EventMediaModelItem]) -> None:
         """Save the device specific model to the store."""
         # Event order is preserved so popping from the oldest entry works
-        data: list[dict[str, Any]] = []
+        device_data: list[dict[str, Any]] = []
         for item in event_data.values():
-            data.append(item.as_dict())
+            device_data.append(item.as_dict())
 
         # Read data from the store and update information for this device
         store_data = await self._cache_policy.store.async_load()
         if not store_data:
             store_data = {}
-        store_data[self._device_id] = data
+        store_data[self._device_id] = device_data
         await self._cache_policy._store.async_save(store_data)
 
     async def get_media(
-        self, event_id: str, width: Optional[int] = None, height: Optional[int] = None
+        self,
+        event_session_id: str,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
     ) -> Optional[EventMedia]:
         """Get media for the specified event.
 
@@ -278,9 +329,21 @@ class EventMediaManager:
         honored (e.g. if image is already cached).
         """
         event_data = await self._async_load()
-        if not (item := event_data.get(event_id)):
+        if not (item := event_data.get(event_session_id)):
             return None
-        event = item.event
+        event = item.visible_event
+        if not event:
+            _LOGGER.debug(
+                "Skipping fetch; No visible event; event_session_id=%s",
+                event_session_id,
+            )
+            return None
+        if event.is_expired:
+            _LOGGER.debug(
+                "Skipping fetch; Event expired; event_session_id=%s", event_session_id
+            )
+            return None
+        _LOGGER.debug("Fetching media for event_session_id=%s", event_session_id)
         if item.media_key:
             media_key = item.media_key
         else:
@@ -304,50 +367,67 @@ class EventMediaManager:
 
     async def async_events(self) -> Iterable[ImageEventBase]:
         """Return revent events."""
-        event_data = await self._async_load()
-        result: list[EventMediaModelItem] = list(event_data.values())
-        result.sort(key=lambda x: x.event.timestamp, reverse=True)
 
         def _filter(x: EventMediaModelItem) -> bool:
             """Return events already fetched or that could be fetched."""
-            return x.media_key is not None or not x.event.is_expired
+            return x.visible_event is not None and (
+                x.media_key is not None or not x.visible_event.is_expired
+            )
 
-        result = list(filter(_filter, result))
+        event_data = await self._async_load()
+        result: list[EventMediaModelItem] = list(filter(_filter, event_data.values()))
 
         def _get_event(x: EventMediaModelItem) -> ImageEventBase:
-            return x.event
+            assert x.visible_event
+            return x.visible_event
 
-        return list(map(_get_event, result))
+        event_result = list(map(_get_event, result))
+        event_result.sort(key=lambda x: x.timestamp, reverse=True)
+        return event_result
 
     async def async_handle_events(self, event_message: EventMessage) -> None:
         """Handle the EventMessage."""
-        events = event_message.resource_update_events
-        if not events:
+        event_sessions: dict[
+            str, dict[str, ImageEventBase]
+        ] | None = event_message.event_sessions
+        if not event_sessions:
             return
-        _LOGGER.debug("Event Update %s", events.keys())
-        for (event_name, event) in events.items():
-            if event_name not in self._event_trait_map:
-                continue
-            self._event_trait_map[event_name].handle_event(event)
+        _LOGGER.debug("Event Update %s", event_sessions.keys())
 
-            # Update event cache
+        # Notify traits to cache events
+        for event_dict in event_sessions.values():
+            for event_name, event in event_dict.items():
+                self._event_trait_map[event_name].handle_event(event)
+
+        # Update interal event media representation
+        for event_session_id, event_dict in event_sessions.items():
+
+            # Track all related events together with the same session
             event_data = await self._async_load()
-            event_data[event.event_id] = EventMediaModelItem(event)
-            if len(event_data) > self._cache_policy.event_cache_size:
-                (key, item) = event_data.popitem(last=False)
-                if item.media_key:
-                    await self._cache_policy.store.async_remove_media(item.media_key)
-            await self._async_update(event_data)
 
-            # We can't fetch media for expired events
-            if event.is_expired:
-                continue
+            if model_item := event_data.get(event_session_id):
+                model_item.events.update(event_dict)
+                # Update the existing event session with new/updated events
+                # for event_type, event in event_dict.items():
+                #    model_item.events[event_type] = event
+            else:
+                # A new event session
+                model_item = EventMediaModelItem(event_session_id, event_dict)
+                event_data[event_session_id] = model_item
+
+                if len(event_data) > self._cache_policy.event_cache_size:
+                    (key, old_item) = event_data.popitem(last=False)
+                    if old_item.media_key:
+                        await self._cache_policy.store.async_remove_media(
+                            old_item.media_key
+                        )
+
+            await self._async_update(event_data)
 
             # Prefetch media, otherwise we may
             if self._cache_policy.fetch:
-                _LOGGER.debug("Fetching media for event_id=%s", event.event_id)
                 try:
-                    await self.get_media(event.event_id)
+                    await self.get_media(event_session_id)
                 except GoogleNestException as err:
                     _LOGGER.warning(
                         "Failure when pre-fetching event '%s': %s",

--- a/tests/google_nest_api_test.py
+++ b/tests/google_nest_api_test.py
@@ -1258,7 +1258,7 @@ async def test_event_manager_image(
                     "name": "enterprises/project-id1/devices/device-id1",
                     "events": {
                         "sdm.devices.events.CameraMotion.Motion": {
-                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "eventSessionId": "QjY5Y3VKaTZwR3o4Y19YbTVfMF...",
                             "eventId": "ABCZQRUdGNUlTU2V4MGV3bRZ23...",
                         },
                     },
@@ -1270,9 +1270,9 @@ async def test_event_manager_image(
 
     event_media_manager = device.event_media_manager
 
-    event_media = await event_media_manager.get_media("FWWVQVUdGNUlTU2V4MGV2aTNXV...")
+    event_media = await event_media_manager.get_media("CjY5Y3VKaTZwR3o4Y19YbTVfMF...")
     assert event_media
-    assert event_media.event_id == "FWWVQVUdGNUlTU2V4MGV2aTNXV..."
+    assert event_media.event_session_id == "CjY5Y3VKaTZwR3o4Y19YbTVfMF..."
     assert event_media.event_type == "sdm.devices.events.CameraMotion.Motion"
     assert event_media.event_timestamp.isoformat(timespec="seconds") == ts1.isoformat(
         timespec="seconds"
@@ -1280,9 +1280,9 @@ async def test_event_manager_image(
     assert event_media.media.contents == b"image-bytes-1"
     assert event_media.media.event_image_type.content_type == "image/jpeg"
 
-    event_media = await event_media_manager.get_media("ABCZQRUdGNUlTU2V4MGV3bRZ23...")
+    event_media = await event_media_manager.get_media("QjY5Y3VKaTZwR3o4Y19YbTVfMF...")
     assert event_media
-    assert event_media.event_id == "ABCZQRUdGNUlTU2V4MGV3bRZ23..."
+    assert event_media.event_session_id == "QjY5Y3VKaTZwR3o4Y19YbTVfMF..."
     assert event_media.event_type == "sdm.devices.events.CameraMotion.Motion"
     assert event_media.event_timestamp.isoformat(timespec="seconds") == ts2.isoformat(
         timespec="seconds"
@@ -1322,12 +1322,6 @@ async def test_event_manager_prefetch_image(
                     "token": "g.1.eventToken",
                 },
             },
-            {
-                "results": {
-                    "url": "image-url-2",
-                    "token": "g.2.eventToken",
-                },
-            },
         ],
     )
 
@@ -1337,9 +1331,6 @@ async def test_event_manager_prefetch_image(
     )
     app.router.add_get(
         "/image-url-1", NewImageHandler([b"image-bytes-1"], token="g.1.eventToken")
-    )
-    app.router.add_get(
-        "/image-url-2", NewImageHandler([b"image-bytes-2"], token="g.2.eventToken")
     )
 
     api = await api_client()
@@ -1374,16 +1365,10 @@ async def test_event_manager_prefetch_image(
     event_media_manager = device.event_media_manager
     assert len(list(await event_media_manager.async_events())) == 0
 
-    # However, manually fetching it could still work
-    event_media = await event_media_manager.get_media("FWWVQVUdGNUlTU2V4MGV2aTNXV...")
-    assert event_media
-    assert event_media.event_id == "FWWVQVUdGNUlTU2V4MGV2aTNXV..."
-    assert event_media.event_type == "sdm.devices.events.CameraMotion.Motion"
-    assert event_media.event_timestamp == ts1
-    assert event_media.media.contents == b"image-bytes-1"
-    assert event_media.media.event_image_type.content_type == "image/jpeg"
-
-    assert len(list(await event_media_manager.async_events())) == 1
+    # And we won't fetch it when asked either
+    event_media = await event_media_manager.get_media("CjY5Y3VKaTZwR3o4Y19YbTVfMF...")
+    assert not event_media
+    assert len(list(await event_media_manager.async_events())) == 0
 
     # Publishing an active event is fetched immediately
     ts2 = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -1405,18 +1390,18 @@ async def test_event_manager_prefetch_image(
             }
         )
     )
-    assert len(list(await event_media_manager.async_events())) == 2
+    assert len(list(await event_media_manager.async_events())) == 1
 
     # However, manually fetching it could still work
     event_media_manager = device.event_media_manager
-    event_media = await event_media_manager.get_media("GXQADVUdGNUlTU2V4MGV2aTNXV...")
+    event_media = await event_media_manager.get_media("DkY5Y3VKaTZwR3o4Y19YbTVfMF...")
     assert event_media
-    assert event_media.event_id == "GXQADVUdGNUlTU2V4MGV2aTNXV..."
+    assert event_media.event_session_id == "DkY5Y3VKaTZwR3o4Y19YbTVfMF..."
     assert event_media.event_type == "sdm.devices.events.CameraMotion.Motion"
     assert event_media.event_timestamp.isoformat(timespec="seconds") == ts2.isoformat(
         timespec="seconds"
     )
-    assert event_media.media.contents == b"image-bytes-2"
+    assert event_media.media.contents == b"image-bytes-1"
     assert event_media.media.event_image_type.content_type == "image/jpeg"
 
 
@@ -1478,7 +1463,7 @@ async def test_event_manager_event_expiration(
                     "name": "enterprises/project-id1/devices/device-id1",
                     "events": {
                         "sdm.devices.events.CameraMotion.Motion": {
-                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "eventSessionId": "DgY5Y3VKaTZwR3o4Y19YbTVfMF...",
                             "eventId": "ABCZQRUdGNUlTU2V4MGV3bRZ23...",
                         },
                     },
@@ -1499,7 +1484,7 @@ async def test_event_manager_event_expiration(
                     "name": "enterprises/project-id1/devices/device-id1",
                     "events": {
                         "sdm.devices.events.CameraMotion.Motion": {
-                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "eventSessionId": "EkY5Y3VKaTZwR3o4Y19YbTVfMF...",
                             "eventId": "1234QRUdGNUlTU2V4MGV3bRZ23...",
                         },
                     },
@@ -1565,7 +1550,7 @@ async def test_event_manager_cache_expiration(
     class TestStore(InMemoryEventMediaStore):
         def get_media_key(self, device_id: str, event: ImageEventBase) -> str:
             """Return a predictable media key."""
-            return event.event_id
+            return event.event_session_id
 
     store = TestStore()
     device.event_media_manager.cache_policy.store = store
@@ -1583,7 +1568,7 @@ async def test_event_manager_cache_expiration(
                         "name": "enterprises/project-id1/devices/device-id1",
                         "events": {
                             "sdm.devices.events.CameraMotion.Motion": {
-                                "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                                "eventSessionId": f"CjY5Y3VK..{i}...",
                                 "eventId": f"FWWVQVU..{i}...",
                             },
                         },
@@ -1598,10 +1583,10 @@ async def test_event_manager_cache_expiration(
     assert len(list(await event_media_manager.async_events())) == 8
 
     # Old items are evicted from the media store
-    assert await store.async_load_media("FWWVQVU..0...") is None
-    assert await store.async_load_media("FWWVQVU..1...") is None
+    assert await store.async_load_media("CjY5Y3VK..0...") is None
+    assert await store.async_load_media("CjY5Y3VK..1...") is None
     for i in range(2, num_events):
-        assert await store.async_load_media(f"FWWVQVU..{i}...") == b"image-bytes-1"
+        assert await store.async_load_media(f"CjY5Y3VK..{i}...") == b"image-bytes-1"
 
 
 async def test_event_manager_prefetch_image_failure(
@@ -1698,7 +1683,7 @@ async def test_event_manager_prefetch_image_failure(
                         "name": "enterprises/project-id1/devices/device-id1",
                         "events": {
                             "sdm.devices.events.CameraMotion.Motion": {
-                                "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                                "eventSessionId": f"CjY5Y...{i}...",
                                 "eventId": f"FWWVQVU..{i}...",
                             },
                         },
@@ -1713,14 +1698,14 @@ async def test_event_manager_prefetch_image_failure(
     assert len(list(events)) == 3
 
     for i in range(1, 4):
-        event_media = await event_media_manager.get_media(f"FWWVQVU..{i}...")
+        event_media = await event_media_manager.get_media(f"CjY5Y...{i}...")
         if i == 1:
             assert not event_media
             continue
 
         ts = now + datetime.timedelta(seconds=i)
         assert event_media
-        assert event_media.event_id == f"FWWVQVU..{i}..."
+        assert event_media.event_session_id == f"CjY5Y...{i}..."
         assert event_media.event_type == "sdm.devices.events.CameraMotion.Motion"
         assert event_media.event_timestamp.isoformat(
             timespec="seconds"
@@ -1844,3 +1829,131 @@ async def test_multi_device_events(
     assert len(list(await event_media_manager.async_events())) == 1
     event_media_manager = devices[1].event_media_manager
     assert len(list(await event_media_manager.async_events())) == 1
+
+
+@pytest.mark.parametrize(
+    "test_trait,test_event_trait",
+    [
+        ("sdm.devices.traits.CameraMotion", "sdm.devices.events.CameraMotion.Motion"),
+        ("sdm.devices.traits.CameraPerson", "sdm.devices.events.CameraPerson.Person"),
+        ("sdm.devices.traits.CameraSound", "sdm.devices.events.CameraSound.Sound"),
+        ("sdm.devices.traits.DoorbellChime", "sdm.devices.events.DoorbellChime.Chime"),
+    ],
+)
+async def test_camera_active_clip_preview_threads(
+    test_trait: str,
+    test_event_trait: str,
+    app: aiohttp.web.Application,
+    api_client: Callable[[], Awaitable[google_nest_api.GoogleNestAPI]],
+    event_message: Callable[[Dict[str, Any]], Awaitable[EventMessage]],
+) -> None:
+    r = Recorder()
+    handler = NewDeviceHandler(
+        r,
+        [
+            {
+                "name": "enterprises/project-id1/devices/device-id1",
+                "traits": {
+                    "sdm.devices.traits.CameraClipPreview": {},
+                    test_trait: {},
+                },
+            },
+        ],
+    )
+
+    async def img_handler(request: aiohttp.web.Request) -> aiohttp.web.Response:
+        assert request.headers["Authorization"] == "Bearer %s" % FAKE_TOKEN
+        return aiohttp.web.Response(body=b"image-bytes-1")
+
+    app.router.add_get("/enterprises/project-id1/devices", handler)
+    app.router.add_get("/image-url-1", img_handler)
+
+    api = await api_client()
+    devices = await api.async_get_devices()
+    assert len(devices) == 1
+    device = devices[0]
+    assert "enterprises/project-id1/devices/device-id1" == device.name
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    await device.async_handle_event(
+        await event_message(
+            {
+                "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+                "timestamp": now.isoformat(timespec="seconds"),
+                "resourceUpdate": {
+                    "name": "enterprises/project-id1/devices/device-id1",
+                    "events": {
+                        test_event_trait: {
+                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "eventId": "n:1",
+                        },
+                        "sdm.devices.events.CameraClipPreview.ClipPreview": {
+                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "previewUrl": "image-url-1",
+                        },
+                    },
+                },
+                "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+                "eventThreadId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                "resourcegroup": [
+                    "enterprises/project-id1/devices/device-id1",
+                ],
+                "eventThreadState": "STARTED",
+            }
+        )
+    )
+    await device.async_handle_event(
+        await event_message(
+            {
+                "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+                "timestamp": now.isoformat(timespec="seconds"),
+                "resourceUpdate": {
+                    "name": "enterprises/project-id1/devices/device-id1",
+                    "events": {
+                        test_event_trait: {
+                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "eventId": "n:1",
+                        },
+                        "sdm.devices.events.CameraClipPreview.ClipPreview": {
+                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                            "previewUrl": "image-url-1",
+                        },
+                    },
+                },
+                "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+                "eventThreadId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                "resourcegroup": [
+                    "enterprises/project-id1/devices/device-id1",
+                ],
+                "eventThreadState": "ENDED",
+            }
+        )
+    )
+
+    # Verify active event traits
+    trait = device.traits[test_trait]
+    assert trait.active_event is not None
+    image = await trait.generate_active_event_image()
+    assert image
+    assert image.event_image_type == EventImageType.CLIP_PREVIEW
+    assert "image-url-1" == image.url
+    assert image.token is None
+
+    # Verify event manager view
+    event_media_manager = devices[0].event_media_manager
+    events = list(await event_media_manager.async_events())
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == test_event_trait
+    assert event.event_session_id == "CjY5Y3VKaTZwR3o4Y19YbTVfMF..."
+    assert event.event_id == "n:1"
+
+    event_media = await event_media_manager.get_media("CjY5Y3VKaTZwR3o4Y19YbTVfMF...")
+    assert event_media
+    assert event_media.event_session_id == "CjY5Y3VKaTZwR3o4Y19YbTVfMF..."
+    assert event_media.event_type == test_event_trait
+    assert event_media.event_timestamp.isoformat(timespec="seconds") == now.isoformat(
+        timespec="seconds"
+    )
+    assert event_media.media.contents == b"image-bytes-1"
+    assert event_media.media.event_image_type.content_type == "image/jpeg"


### PR DESCRIPTION
Update event manager to group sessions by events, so that camera clip
previews are associated with the original event.

This is a large rewrite of the event map.