### PR TITLE
Fix events, for incremental events within the same session

### DIFF
--- a/google_nest_sdm/event.py
+++ b/google_nest_sdm/event.py
@@ -353,6 +353,17 @@ class EventMessage:
         """Return raw data for the event."""
         return dict(self._raw_data)
 
+    def omit_events(self, omit_event_keys: Iterable[str]) -> EventMessage:
+        """Create a new EventMessage minus some existing events by key."""
+        raw_data = dict(self._raw_data)
+        events = raw_data[RESOURCE_UPDATE].get(EVENTS, {})
+        for key in omit_event_keys:
+            if key not in events:
+                continue
+            del events[key]
+        raw_data[RESOURCE_UPDATE][EVENTS] = events
+        return EventMessage(raw_data, self._auth)
+
 
 class EventTypeFilterCallback:
     """Invoke a delegate only for events that match the trait type."""

--- a/tests/device_manager_test.py
+++ b/tests/device_manager_test.py
@@ -525,7 +525,18 @@ async def test_update_trait_ordering(
     assert get_connectivity().status == "ONLINE"
 
 
+@pytest.mark.parametrize(
+    "test_trait,test_event_trait",
+    [
+        ("sdm.devices.traits.CameraMotion", "sdm.devices.events.CameraMotion.Motion"),
+        ("sdm.devices.traits.CameraPerson", "sdm.devices.events.CameraPerson.Person"),
+        ("sdm.devices.traits.CameraSound", "sdm.devices.events.CameraSound.Sound"),
+        ("sdm.devices.traits.DoorbellChime", "sdm.devices.events.DoorbellChime.Chime"),
+    ],
+)
 async def test_device_added_after_callback(
+    test_trait: str,
+    test_event_trait: str,
     fake_device: Callable[[Dict[str, Any]], Device],
     fake_event_message: Callable[[Dict[str, Any]], EventMessage],
 ) -> None:
@@ -548,7 +559,8 @@ async def test_device_added_after_callback(
             "name": "my/device/name1",
             "type": "sdm.devices.types.SomeDeviceType",
             "traits": {
-                "sdm.devices.traits.CameraMotion": {},
+                test_trait: {},
+                "sdm.devices.traits.CameraEventImage": {},
             },
         }
     )
@@ -563,7 +575,7 @@ async def test_device_added_after_callback(
                 "resourceUpdate": {
                     "name": "my/device/name1",
                     "events": {
-                        "sdm.devices.events.CameraMotion.Motion": {
+                        test_event_trait: {
                             "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
                             "eventId": "n:1",
                         },


### PR DESCRIPTION
Publish partial messages with new events when messages for the same session are published.  Example:

event#1
session_id=1, {CameraMotion}
event#2
session_id=1, {CameraPerson, CameraMotion}

Previously only a single CameraMotion was published. Now a separate CameraPerson is also published.