### PR TITLE
Return EventMedia when fetching content from tokens

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -101,6 +101,11 @@ class Media:
         """Content event image type of the media."""
         return self._event_image_type
 
+    @property
+    def content_type(self) -> str:
+        """Content type of the media."""
+        return self._event_image_type.content_type
+
 
 class ImageSession(ABC):
     """An object that holds events that happened within a time range."""
@@ -529,7 +534,7 @@ class EventMediaManager:
             _LOGGER.debug("Saving media %s (%s)", media_key, item.event_session_id)
             await store.async_save_media(media_key, content)
 
-    async def get_media_from_token(self, event_token: str) -> bytes | None:
+    async def get_media_from_token(self, event_token: str) -> Media | None:
         """Get media based on the event token."""
         token = EventToken.decode(event_token)
         event_data = await self._async_load()
@@ -551,7 +556,8 @@ class EventMediaManager:
                 item.media_key,
             )
             return None
-        return contents
+        assert item.visible_event
+        return Media(contents, item.visible_event.event_image_type)
 
     async def async_events(self) -> Iterable[ImageEventBase]:
         """Return revent events."""

--- a/tests/event_media_test.py
+++ b/tests/event_media_test.py
@@ -1194,8 +1194,10 @@ async def test_event_session_image(
         timespec="seconds"
     )
 
-    content = await event_media_manager.get_media_from_token(event.event_token)
-    assert content == b"image-bytes-2"
+    media = await event_media_manager.get_media_from_token(event.event_token)
+    assert media
+    assert media.contents == b"image-bytes-2"
+    assert media.content_type == "image/jpeg"
 
     event = events[1]
     event_token = EventToken.decode(event.event_token)
@@ -1206,8 +1208,10 @@ async def test_event_session_image(
         timespec="seconds"
     )
 
-    content = await event_media_manager.get_media_from_token(event.event_token)
-    assert content == b"image-bytes-1"
+    media = await event_media_manager.get_media_from_token(event.event_token)
+    assert media
+    assert media.contents == b"image-bytes-1"
+    assert media.content_type == "image/jpeg"
 
 
 async def test_event_session_clip_preview(
@@ -1307,8 +1311,10 @@ async def test_event_session_clip_preview(
         timespec="seconds"
     )
 
-    content = await event_media_manager.get_media_from_token(event.event_token)
-    assert content == b"image-bytes-1"
+    media = await event_media_manager.get_media_from_token(event.event_token)
+    assert media
+    assert media.contents == b"image-bytes-1"
+    assert media.content_type == "video/mp4"
 
 
 async def test_persisted_storage_image(
@@ -1380,8 +1386,10 @@ async def test_persisted_storage_image(
     assert event.event_type == "sdm.devices.events.DoorbellChime.Chime"
     assert event.timestamp.isoformat(timespec="seconds") == "2021-12-23T06:35:36+00:00"
 
-    content = await event_media_manager.get_media_from_token(event.event_token)
-    assert content == b"image-bytes-1"
+    media = await event_media_manager.get_media_from_token(event.event_token)
+    assert media
+    assert media.contents == b"image-bytes-1"
+    assert media.content_type == "image/jpeg"
 
     event = events[1]
     event_token = EventToken.decode(event.event_token)
@@ -1390,8 +1398,10 @@ async def test_persisted_storage_image(
     assert event.event_type == "sdm.devices.events.CameraMotion.Motion"
     assert event.timestamp.isoformat(timespec="seconds") == "2021-12-23T06:35:35+00:00"
 
-    content = await event_media_manager.get_media_from_token(event.event_token)
-    assert content == b"image-bytes-1"
+    media = await event_media_manager.get_media_from_token(event.event_token)
+    assert media
+    assert media.contents == b"image-bytes-1"
+    assert media.content_type == "image/jpeg"
 
     # Use original APIs
     event_media = await event_media_manager.get_media("AVPHwEtyzgSxu6EuaIOfvz...")
@@ -1481,8 +1491,10 @@ async def test_persisted_storage_clip_preview(
     ]
     assert event.timestamp.isoformat(timespec="seconds") == "2021-12-21T21:13:18+00:00"
 
-    content = await event_media_manager.get_media_from_token(event.event_token)
-    assert content == b"image-bytes-1"
+    media = await event_media_manager.get_media_from_token(event.event_token)
+    assert media
+    assert media.contents == b"image-bytes-1"
+    assert media.content_type == "video/mp4"
 
     # Use original APIs
     event_media = await event_media_manager.get_media("1632710204")


### PR DESCRIPTION
Return EventMedia so that bytes + content type are returned to make calling code slightly simpler.