### PR TITLE
Make AuthException derived from ApiException

### DIFF
--- a/google_nest_sdm/exceptions.py
+++ b/google_nest_sdm/exceptions.py
@@ -13,7 +13,7 @@ class ApiException(GoogleNestException):
     """Raised during problems talking to the API."""
 
 
-class AuthException(GoogleNestException):
+class AuthException(ApiException):
     """Raised due to auth problems talking to API or subscriber."""
 
 


### PR DESCRIPTION
Make AuthException subclass ApiException for improved exception catching
in Home Assistant. Currently ApiException and AuthException can be thrown
in the API calls, where it currently catches the more broad
GoogleNestException. 

Follow on from discussion in https://github.com/home-assistant/core/pull/63207