### PR TITLE
Ignore an unreachable mypy warning for failures in #151

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,4 @@ warn_unreachable = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_no_return = True
+show_error_codes = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,7 @@ no_implicit_optional = True
 warn_return_any = True
 warn_unreachable = True
 warn_redundant_casts = True
-warn_unused_ignores = True
 warn_no_return = True
 show_error_codes = True
+# For temporarily dealing with mypy updates (#151 and #152)
+warn_unused_ignores = False

--- a/tests/device_manager_test.py
+++ b/tests/device_manager_test.py
@@ -255,7 +255,7 @@ async def test_device_event_callback(
     assert callback.invoked
 
     # Test event not for this device
-    callback.invoked = False
+    callback.invoked = False  # type: ignore[unreachble]
     await mgr.async_handle_event(
         fake_event_message(
             {


### PR DESCRIPTION
I couldn't find an issue tracking this in mypy but not sure this test code is worth more attention.