### PR TITLE
Upgrade aiohttp and async-timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-aiohttp==3.7.4.post0
+aiohttp==3.8.1
 aiosignal==1.2.0
 appdirs==1.4.4
-async-timeout==3.0.1
+async-timeout==4.0.2
 attrs==21.4.0
 backports.entry-points-selectable==1.1.1
 black==20.8b1


### PR DESCRIPTION
Manually upgrade since the renovate configuration is having trouble with version major/minor mismatches