### PR TITLE
Allow unused mypy `ignore` errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,5 @@ warn_unreachable = True
 warn_redundant_casts = True
 warn_no_return = True
 show_error_codes = True
+# For temporarily dealing with mypy updates (#151 and #152)
+warn_unused_ignores = False


### PR DESCRIPTION
To support ignoring unused stuff across version upgrades, etc.