### PR TITLE
Expire clip thumbnails when cache is filled

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -518,6 +518,15 @@ class EventMediaManager:
                 await self._cache_policy.store.async_remove_media(
                     old_item.media_key
                 )
+            if old_item.thumbnail_media_key:
+                _LOGGER.debug(
+                    "Expiring media %s (%s)",
+                    old_item.thumbnail_media_key,
+                    old_item.event_session_id,
+                )
+                await self._cache_policy.store.async_remove_media(
+                    old_item.thumbnail_media_key
+                )
             for old_media_key in old_item.event_media_keys.values():
                 _LOGGER.debug(
                     "Expiring event media %s (%s)",


### PR DESCRIPTION
Ensure that transcoded thumbnail clips are also expired from the cache like all other media. Fixes a bug where they could be left orphaned.