### PR TITLE
Add device-specific diagnostics

### DIFF
--- a/google_nest_sdm/diagnostics.py
+++ b/google_nest_sdm/diagnostics.py
@@ -28,10 +28,12 @@ class Diagnostics:
 
 
 SUBSCRIBER_DIAGNOSTICS = Diagnostics()
+EVENT_DIAGNOSTICS = Diagnostics()
 EVENT_MEDIA_DIAGNOSTICS = Diagnostics()
 
 MAP = {
     "subscriber": SUBSCRIBER_DIAGNOSTICS,
+    "event": EVENT_DIAGNOSTICS,
     "event_media": EVENT_MEDIA_DIAGNOSTICS,
 }
 
@@ -43,4 +45,36 @@ def reset() -> None:
 
 
 def get_diagnostics() -> dict[str, Any]:
-    return {k: v.as_dict() for (k, v) in MAP.items()}
+    return {k: v.as_dict() for (k, v) in MAP.items() if v.as_dict()}
+
+
+REDACT_KEYS = {
+    "name",
+    "customName",
+    "displayName",
+    "parent",
+    "assignee",
+    "subject",
+    "object",
+    "userId",
+    "resourceGroup",
+    "eventId",
+    "eventSessionId",
+    "eventThreadId",
+}
+REDACTED = "**REDACTED**"
+
+
+def redact_data(data: Mapping) -> dict[str, Any]:
+    """Redact sensitive data in a dict."""
+    redacted = {**data}
+
+    for key, value in redacted.items():
+        if key in REDACT_KEYS:
+            redacted[key] = REDACTED
+        elif isinstance(value, dict):
+            redacted[key] = redact_data(value)
+        elif isinstance(value, list):
+            redacted[key] = [redact_data(item) for item in value]
+
+    return redacted

--- a/google_nest_sdm/event.py
+++ b/google_nest_sdm/event.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 from .auth import AbstractAuth
+from .diagnostics import EVENT_DIAGNOSTICS as DIAGNOSTICS
 from .exceptions import DecodeException
 from .registry import Registry
 from .traits import BuildTraits, Command
@@ -418,7 +419,7 @@ class EventMessage:
         """Return the set of traits that were updated."""
         if not self.resource_update_name:
             return None
-        cmd = Command(self.resource_update_name, self._auth)
+        cmd = Command(self.resource_update_name, self._auth, DIAGNOSTICS)
         events = self._raw_data[RESOURCE_UPDATE].get(TRAITS, {})
         return BuildTraits(events, cmd)
 

--- a/tests/camera_traits_test.py
+++ b/tests/camera_traits_test.py
@@ -236,6 +236,20 @@ async def test_camera_live_stream_rtsp(
         },
     }
 
+    assert device.get_diagnostics() == {
+        "data": {
+            "name": "**REDACTED**",
+            "parentRelations": [],
+            "traits": {"sdm.devices.traits.CameraLiveStream": {}},
+            "type": "sdm.devices.types.device-type1",
+        },
+        "diagnostics": {
+            "sdm.devices.commands.CameraLiveStream.ExtendRtspStream": 2,
+            "sdm.devices.commands.CameraLiveStream.GenerateRtspStream": 1,
+            "sdm.devices.commands.CameraLiveStream.StopRtspStream": 1,
+        },
+    }
+
 
 async def test_camera_live_stream_web_rtc(
     app: aiohttp.web.Application,

--- a/tests/event_media_test.py
+++ b/tests/event_media_test.py
@@ -142,7 +142,6 @@ async def test_event_manager_image(
             "load_events": 1,
             "save_media": 2,
         },
-        "subscriber": {},
     }
 
 
@@ -440,7 +439,6 @@ async def test_event_manager_cache_expiration(
             "save_media": 10,
             "remove_media": 2,
         },
-        "subscriber": {},
     }
 
 
@@ -583,7 +581,6 @@ async def test_event_manager_prefetch_image_failure(
             "remove_media": 1,
             "save_media": 4,
         },
-        "subscriber": {},
     }
 
 
@@ -825,7 +822,6 @@ async def test_camera_active_clip_preview_threads(
             "load_events": 1,
             "save_media": 1,
         },
-        "subscriber": {},
     }
 
 

--- a/tests/google_nest_subscriber_test.py
+++ b/tests/google_nest_subscriber_test.py
@@ -132,7 +132,6 @@ async def test_subscribe_device_manager(
     subscriber.stop_async()
 
     assert diagnostics.get_diagnostics() == {
-        "event_media": {},
         "subscriber": {
             "start": 1,
             "stop": 1,
@@ -288,7 +287,6 @@ async def test_subscriber_error(
     subscriber.stop_async()
 
     assert diagnostics.get_diagnostics() == {
-        "event_media": {},
         "subscriber": {
             "start": 1,
             "start.api_error": 1,


### PR DESCRIPTION
Add device specific diagnostics and counters. Cleanup exports to only include present keys to simplify test impact.
Issue #189