### PR TITLE
Fix bug where event media is returned when the media fetch fails

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -749,7 +749,11 @@ class EventMediaManager:
 
         def _get_events(x: EventMediaModelItem) -> list[ImageEventBase]:
             # Only return events that have successful media fetches
-            return [y for y in x.events.values() if y.event_id in x.event_media_keys]
+            return [
+                y
+                for y in x.events.values()
+                if x.media_key or y.event_id in x.event_media_keys
+            ]
 
         result = await self._items_with_media()
         events_list = list(map(_get_events, result))

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -748,7 +748,8 @@ class EventMediaManager:
         self._diagnostics.increment("load_image_sessions")
 
         def _get_events(x: EventMediaModelItem) -> list[ImageEventBase]:
-            return list(x.events.values())
+            # Only return events that have successful media fetches
+            return [y for y in x.events.values() if y.event_id in x.event_media_keys]
 
         result = await self._items_with_media()
         events_list = list(map(_get_events, result))

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ filterwarnings =
     ignore:.*decorator is deprecated since Python 3.8, use "async def" instead
     ignore:.*Call to deprecated create function .*Descriptor.*
 asyncio_mode = auto
+log_cli = true


### PR DESCRIPTION
Fix bug where event media is returned when the media fetch fails. Now it will check and verify the event id is in the list of keys that have media.