### PR TITLE
Require python3.9 as that is the min version tested

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "requests-oauthlib>=1.3.0",
         "PyYAML==6.0",
     ],
+    python_requires=">=3.9",
     entry_points={
         "console_scripts": [
             "google_nest=google_nest_sdm.google_nest:main",


### PR DESCRIPTION
Require python3.9 as that is the min version tested

Fixes #290