### PR TITLE
Renovate config: Group all flake8 prefixed packages together

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,7 +13,7 @@
       "groupName": "group:flake8",
       "matchPackageNames": ["flake8"],
       "matchPackagePrefixes": [
-          "flake8-",
+          "flake8",
           "pyflakes",
           "mccabe",
           "pycodestyle",


### PR DESCRIPTION
Group all flake8 prefixed packages together in renovate config so that PRs can be accepted together without version conflicts.