### PR TITLE
Lower log level of event media

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -529,10 +529,10 @@ class EventMediaManager:
             self._lock = asyncio.Lock()
         async with self._lock:
             event_data = await self._async_load()
-            _LOGGER.info("Checking cache size %s", len(event_data))
+            _LOGGER.debug("Checking cache size %s", len(event_data))
             if len(event_data) <= self._cache_policy.event_cache_size:
                 return
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Expiring cache %s", self._cache_policy.event_cache_expire_count
             )
             # Bulk pop items


### PR DESCRIPTION
Lower log level of event media
```
2022-12-11 14:50:40.519 INFO (MainThread) [google_nest_sdm.event_media] Checking cache size 3
```