### PR TITLE
Add latency diagnostics for subscriber events

### DIFF
--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -296,19 +296,19 @@ class InMemoryEventMediaStore(EventMediaStore):
 
     async def async_load_media(self, media_key: str) -> bytes | None:
         """Load media content."""
-        DIAGNOSTICS.increment("load_media")
-        return self._media.get(media_key)
+        with DIAGNOSTICS.timer("load_media"):
+            return self._media.get(media_key)
 
     async def async_save_media(self, media_key: str, content: bytes) -> None:
         """Remove media content."""
-        DIAGNOSTICS.increment("save_media")
-        self._media[media_key] = content
+        with DIAGNOSTICS.timer("save_media"):
+            self._media[media_key] = content
 
     async def async_remove_media(self, media_key: str) -> None:
         """Remove media content."""
-        DIAGNOSTICS.increment("remove_media")
-        if media_key in self._media:
-            del self._media[media_key]
+        with DIAGNOSTICS.timer("remove_media"):
+            if media_key in self._media:
+                del self._media[media_key]
 
 
 class EventMediaModelItem:

--- a/tests/test_event_media.py
+++ b/tests/test_event_media.py
@@ -145,7 +145,7 @@ async def test_event_manager_image(
         diagnostics.get_diagnostics(),
         {
             "event_media": {
-                "save_media": 2,
+                "save_media_count": 2,
             },
         },
     )
@@ -462,9 +462,9 @@ async def test_event_manager_cache_expiration(
         diagnostics.get_diagnostics(),
         {
             "event_media": {
-                "load_media": 10,
-                "save_media": 10,
-                "remove_media": 2,
+                "load_media_count": 10,
+                "save_media_count": 10,
+                "remove_media_count": 2,
             },
         },
     )
@@ -625,9 +625,9 @@ async def test_event_manager_prefetch_image_failure(
         diagnostics.get_diagnostics(),
         {
             "event_media": {
-                "load_media": 3,
-                "remove_media": 1,
-                "save_media": 4,
+                "load_media_count": 3,
+                "remove_media_count": 1,
+                "save_media_count": 4,
             },
         },
     )
@@ -996,7 +996,7 @@ async def test_camera_active_clip_preview_threads(
         diagnostics.get_diagnostics(),
         {
             "event_media": {
-                "save_media": 1,
+                "save_media_count": 1,
             },
         },
     )

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -25,7 +25,7 @@ from google_nest_sdm.google_nest_subscriber import (
     get_api_env,
 )
 
-from .conftest import DeviceHandler, StructureHandler
+from .conftest import DeviceHandler, StructureHandler, assert_diagnostics
 
 PROJECT_ID = "project-id1"
 SUBSCRIBER_ID = "projects/some-project-id/subscriptions/subscriber-id1"
@@ -132,12 +132,15 @@ async def test_subscribe_device_manager(
     assert devices[device_id2].type == "sdm.devices.types.device-type2"
     subscriber.stop_async()
 
-    assert diagnostics.get_diagnostics() == {
-        "subscriber": {
-            "start": 1,
-            "stop": 1,
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "subscriber": {
+                "start": 1,
+                "stop": 1,
+            },
         },
-    }
+    )
 
 
 async def test_subscribe_update_trait(
@@ -188,23 +191,29 @@ async def test_subscribe_update_trait(
     assert "OFFLINE" == trait.status
     subscriber.stop_async()
 
-    assert diagnostics.get_diagnostics() == {
-        "subscriber": {
-            "message_acked": 1,
-            "message_received": 1,
-            "start": 1,
-            "stop": 1,
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "subscriber": {
+                "message_acked_count": 1,
+                "message_received_count": 1,
+                "start": 1,
+                "stop": 1,
+            },
         },
-    }
-    assert device.get_diagnostics() == {
-        "event_media": {"event": 1},
-        "data": {
-            "name": "**REDACTED**",
-            "parentRelations": [],
-            "traits": {"sdm.devices.traits.Connectivity": {"status": "ONLINE"}},
-            "type": "sdm.devices.types.device-type1",
+    )
+    assert_diagnostics(
+        device.get_diagnostics(),
+        {
+            "event_media": {"event": 1},
+            "data": {
+                "name": "**REDACTED**",
+                "parentRelations": [],
+                "traits": {"sdm.devices.traits.Connectivity": {"status": "ONLINE"}},
+                "type": "sdm.devices.types.device-type1",
+            },
         },
-    }
+    )
 
 
 async def test_subscribe_device_manager_init(
@@ -295,13 +304,16 @@ async def test_subscriber_error(
         await subscriber.start_async()
     subscriber.stop_async()
 
-    assert diagnostics.get_diagnostics() == {
-        "subscriber": {
-            "start": 1,
-            "start.api_error": 1,
-            "stop": 1,
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "subscriber": {
+                "start": 1,
+                "start.api_error": 1,
+                "stop": 1,
+            },
         },
-    }
+    )
 
 
 async def test_subscriber_auth_error(


### PR DESCRIPTION
Add latency diagnostics for subscriber events and media events
- Calculate duration from message timestamp to receive, and  how long it takes to be acked
- Calculate duration for media save, load, remove