### PR TITLE
Only send events when clip contents are actually available

### DIFF
--- a/google_nest_sdm/camera_traits.py
+++ b/google_nest_sdm/camera_traits.py
@@ -468,7 +468,9 @@ class CameraClipPreviewTrait(EventImageGenerator):
                     preview_event = session_event
                     break
             if preview_event is None:
-                _LOGGER.debug("Ignoring event, not the right type: %s", event)
+                _LOGGER.debug(
+                    "Event did not contain fetchable camera clip preview: %s", event
+                )
                 return None
         # Clip preview events have the url baked in without an additional
         # step to generate the image

--- a/google_nest_sdm/event.py
+++ b/google_nest_sdm/event.py
@@ -32,6 +32,8 @@ SUBJECT = "subject"
 OBJECT = "object"
 PREVIEW_URL = "previewUrl"
 ZONES = "zones"
+EVENT_THREAD_STATE = "eventThreadState"
+EVENT_THREAD_STATE_ENDED = "ENDED"
 
 # Event images expire 30 seconds after the event is published
 EVENT_IMAGE_EXPIRE_SECS = 30
@@ -451,3 +453,8 @@ class EventMessage:
             del events[key]
         raw_data[RESOURCE_UPDATE][EVENTS] = events
         return EventMessage(raw_data, self._auth)
+
+    @property
+    def is_thread_ended(self) -> bool:
+        """Return true if the message indicates the thread is ended."""
+        return self._raw_data.get(EVENT_THREAD_STATE) == EVENT_THREAD_STATE_ENDED

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -906,16 +906,12 @@ class EventMediaManager:
                         event.event_session_id,
                         str(err),
                     )
-                    # Fall through and deliver notifications. The model
-                    # item was not changed since no new media was fetched
-                    # await self._async_update_item(model_item)
+
                 # Update any new media keys
                 await self._async_update_item(model_item)
 
-                # We typicaly wait to deliver notifications until media
-                # is fetched, however there are a couple corner cases:
-                # - if we intended to fetch media and it failed, deliver anyway
-                # - if the thread is ending and there was no media, deliver anyway
+                # If no media was fetched, then pause until we get a message that contains
+                # media or the thread ends.
                 if (
                     model_item.any_media_key is None
                     and not event_message.is_thread_ended

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -869,23 +869,22 @@ class EventMediaManager:
         # to downstream subscribers the first time they are seen to avoid
         # firing on updated event threads multiple times.
         suppress_keys: set[str] = set({})
-        valid_events = 0
+        notifiable_events: dict[str, int] = {}  # Notifiable events for each session
         for event_session_id, event_dict in event_sessions.items():
-
             # Track all related events together with the same session
             if model_item := await self._async_load_item(event_session_id):
                 self._diagnostics.increment("event.update")
                 # Update the existing event session with new/updated events. Only
                 # new events are published.
                 suppress_keys |= set(model_item.events.keys())
-                valid_events += len(
+                notifiable_events[event_session_id] = len(
                     set(event_dict.keys()) - set(model_item.events.keys())
                 )
                 model_item.events.update(event_dict)
             else:
                 self._diagnostics.increment("event.new")
                 # A new event session
-                valid_events += len(event_dict.keys())
+                notifiable_events[event_session_id] = len(event_dict.keys())
                 model_item = EventMediaModelItem(
                     event_session_id,
                     event_dict,
@@ -907,8 +906,24 @@ class EventMediaManager:
                         event.event_session_id,
                         str(err),
                     )
+                    # Fall through and deliver notifications. The model
+                    # item was not changed since no new media was fetched
+                    # await self._async_update_item(model_item)
                 # Update any new media keys
                 await self._async_update_item(model_item)
+
+                # We typicaly wait to deliver notifications until media
+                # is fetched, however there are a couple corner cases:
+                # - if we intended to fetch media and it failed, deliver anyway
+                # - if the thread is ending and there was no media, deliver anyway
+                if (
+                    model_item.any_media_key is None
+                    and not event_message.is_thread_ended
+                ):
+                    _LOGGER.debug(
+                        "Skipping notification without media; Will deliver later"
+                    )
+                    notifiable_events[event_session_id] = 0
 
         await self._expire_cache()
 
@@ -917,9 +932,14 @@ class EventMediaManager:
         # Notify any listeners about the arrival of a new event
         if suppress_keys:
             event_message = event_message.omit_events(suppress_keys)
-        if valid_events > 0:
+        if any(notifiable_events.values()):
+            _LOGGER.debug("Message contains notifiable events: %s", notifiable_events)
             self._diagnostics.increment("event.notify")
             await self._callback(event_message)
+        else:
+            _LOGGER.debug(
+                "Message did not contain notifiable events: %s", notifiable_events
+            )
 
     @property
     def active_event_trait(self) -> EventImageGenerator | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,7 +346,7 @@ class EventCallback:
 
     def __init__(self) -> None:
         """Initialize EventCallback."""
-        self.invoked = False
+        self.invoked: bool = False
         self.messages: list[EventMessage] = []
 
     async def async_handle_event(self, event_message: EventMessage) -> None:

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -9,6 +9,8 @@ from google_nest_sdm.device_traits import ConnectivityTrait
 from google_nest_sdm.event import EventMessage
 from google_nest_sdm.structure import Structure
 
+from .conftest import EventCallback
+
 
 @pytest.fixture
 def event_message_with_time(
@@ -220,14 +222,7 @@ async def test_device_event_callback(
     trait = device.traits["sdm.devices.traits.Connectivity"]
     assert "OFFLINE" == trait.status
 
-    class MyCallback:
-        def __init__(self) -> None:
-            self.invoked = False
-
-        async def async_handle_event(self, event_message: EventMessage) -> None:
-            self.invoked = True
-
-    callback = MyCallback()
+    callback = EventCallback()
     unregister = device.add_event_callback(callback.async_handle_event)
     assert not callback.invoked
 
@@ -330,7 +325,6 @@ async def test_device_update_listener(
             self.invoked = False
 
         def async_handle_event(self) -> None:
-            print("async_handle_event")
             self.invoked = True
 
     callback = MyCallback()
@@ -524,14 +518,7 @@ async def test_device_added_after_callback(
 ) -> None:
     """Test event callback is registered before the device is added."""
 
-    class MyCallback:
-        def __init__(self) -> None:
-            self.invoked = False
-
-        async def async_handle_event(self, event_message: EventMessage) -> None:
-            self.invoked = True
-
-    callback = MyCallback()
+    callback = EventCallback()
     mgr = DeviceManager()
     mgr.set_update_callback(callback.async_handle_event)
     assert not callback.invoked
@@ -587,14 +574,7 @@ async def test_publish_without_media(
 ) -> None:
     """Test event callback is registered before the device is added."""
 
-    class MyCallback:
-        def __init__(self) -> None:
-            self.invoked = False
-
-        async def async_handle_event(self, event_message: EventMessage) -> None:
-            self.invoked = True
-
-    callback = MyCallback()
+    callback = EventCallback()
     mgr = DeviceManager()
     mgr.set_update_callback(callback.async_handle_event)
     assert not callback.invoked

--- a/tests/test_event_media.py
+++ b/tests/test_event_media.py
@@ -1726,8 +1726,8 @@ async def test_event_session_without_clip(
     )
 
     # The event ENDED without any media, so notify
-    assert callback.invoked
-    assert len(callback.messages) == 1
+    assert callback.invoked  # type: ignore[unreachable]
+    assert len(callback.messages) == 1  # type: ignore[unreachable]
 
     event_media_manager = device.event_media_manager
 
@@ -1836,8 +1836,8 @@ async def test_event_session_clip_preview_in_second_message(
     )
 
     # Callback invoked now that media arrived
-    assert callback.invoked
-    assert_diagnostics(
+    assert callback.invoked  # type: ignore[unreachable]
+    assert_diagnostics(  # type: ignore[unreachable]
         device.get_diagnostics().get("event_media", {}),
         {
             "event": 2,


### PR DESCRIPTION
Only send events when clip contents are actually available. This may delay a notification, but is more consistent with the current API semantics and expectations.

A followup may be to include a "fast" event type for doorbell events without media.