### PR TITLE
Remove unnecessary dependencies on asynctest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiohttp==3.8.3
 async-timeout==4.0.2
-asynctest==0.13.0
 attrs==22.2.0
 black==22.12.0
 coverage==7.0.5

--- a/tests/test_transcoder.py
+++ b/tests/test_transcoder.py
@@ -1,6 +1,6 @@
+import asyncio
 from unittest.mock import Mock, patch
 
-import asynctest
 import pytest
 
 from google_nest_sdm.exceptions import TranscodeException
@@ -33,7 +33,7 @@ async def test_transcoder(tmp_path: str) -> None:
         "google_nest_sdm.transcoder.asyncio.create_subprocess_shell"
     ) as mock_shell:
         process_mock = Mock()
-        future = asynctest.asyncio.Future()
+        future: asyncio.Future = asyncio.Future()
         future.set_result(("", ""))
         process_mock.communicate.return_value = future
         process_mock.returncode = 0
@@ -49,7 +49,7 @@ async def test_transcoder_failure(tmp_path: str) -> None:
         "google_nest_sdm.transcoder.asyncio.create_subprocess_shell"
     ) as mock_shell, pytest.raises(TranscodeException):
         process_mock = Mock()
-        future = asynctest.asyncio.Future()
+        future: asyncio.Future = asyncio.Future()
         future.set_result(("", ""))
         process_mock.communicate.return_value = future
         process_mock.returncode = 1


### PR DESCRIPTION
Remove an unnecessary dependency on asynctest which is deprecated and [not maintained](https://github.com/Martiusweb/asynctest/issues/163).

This was raised in https://github.com/allenporter/python-google-nest-sdm/pull/490 as not compatible with python 3.11 and failing with: https://github.com/allenporter/python-google-nest-sdm/actions/runs/3779295241/jobs/6424441899