### PR TITLE
Handle TimeoutError gracefully with ApiExceptions

### DIFF
--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -527,8 +527,6 @@ class GoogleNestSubscriber:
         ):
             await self._device_manager_task.result().async_handle_event(event)
             message.ack()
-        else:
-            _LOGGER.debug("Ignoring message since device manager is not ready")
 
         ack_latency_ms = int((time.time() - recv) * 1000)
         DIAGNOSTICS.elapsed("message_acked", ack_latency_ms)

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -518,9 +518,17 @@ class GoogleNestSubscriber:
         DIAGNOSTICS.elapsed("message_received", latency_ms)
         # Only accept device events once the Device Manager has been loaded.
         # We are ok with missing messages on startup since the device manager
-        # will do a live read .
-        if self._device_manager_task and self._device_manager_task.done():
+        # will do a live read. This checks for an exception to avoid throwing
+        # inside the pubsub callback and further weding the pubsub client library.
+        if (
+            self._device_manager_task
+            and self._device_manager_task.done()
+            and not self._device_manager_task.exception()
+        ):
             await self._device_manager_task.result().async_handle_event(event)
             message.ack()
+        else:
+            _LOGGER.debug("Ignoring message since device manager is not ready")
+
         ack_latency_ms = int((time.time() - recv) * 1000)
         DIAGNOSTICS.elapsed("message_acked", ack_latency_ms)

--- a/tests/test_google_nest_api.py
+++ b/tests/test_google_nest_api.py
@@ -140,7 +140,7 @@ async def test_client_error(
     # No server endpoint registered
     api = await api_client()
     with patch(
-        "google_nest_sdm.google_nest_api.AbstractAuth.request",
+        "google_nest_sdm.google_nest_api.AbstractAuth._request",
         side_effect=aiohttp.ClientConnectionError(),
     ), pytest.raises(ApiException):
         await api.async_get_structures()


### PR DESCRIPTION
Handle TimeoutError gracefully with ApiExceptions. Ignore device manager errors in the pubsub callback, rather than just checking if its done and propagating them.

Downstream issue: https://github.com/home-assistant/core/issues/85889