### PR TITLE
Use pydantic for parsing device traits

### DIFF
--- a/google_nest_sdm/device_traits.py
+++ b/google_nest_sdm/device_traits.py
@@ -1,33 +1,25 @@
 """Library for traits about devices."""
 
 import datetime
-from typing import Any, Dict, Mapping, Optional, cast, Final
+from typing import Any, Dict, Final
 
 
 try:
-    from pydantic.v1 import Field, validator
+    from pydantic.v1 import Field
 except ImportError:
-    from pydantic import Field, validator  # type: ignore
+    from pydantic import Field  # type: ignore
 
 import aiohttp
 
-from .traits import TRAIT_MAP, Command, CommandModel
+from .traits import TRAIT_MAP, CommandModel
 from .model import TraitModel
-from .typing import cast_assert, cast_optional
-
-STATUS = "status"
-TIMER_MODE = "timerMode"
-TIMER_TIMEOUT = "timerTimeout"
-CUSTOM_NAME = "customName"
-AMBIENT_HUMIDITY_PERCENT = "ambientHumidityPercent"
-AMBIENT_TEMPERATURE_CELSIUS = "ambientTemperatureCelsius"
 
 
 @TRAIT_MAP.register()
 class ConnectivityTrait(TraitModel):
     """This trait belongs to any device that has connectivity information."""
 
-    NAME: Final ="sdm.devices.traits.Connectivity"
+    NAME: Final = "sdm.devices.traits.Connectivity"
 
     status: str
     """Device connectivity status.
@@ -43,17 +35,17 @@ class FanTrait(CommandModel):
 
     NAME: Final = "sdm.devices.traits.Fan"
 
-    timer_mode: str | None = Field(alias=TIMER_MODE)
+    timer_mode: str | None = Field(alias="timerMode")
     """Timer mode for the fan.
 
     Return:
         "ON", "OFF"
     """
 
-    timer_timeout: datetime.datetime | None = Field(alias=TIMER_TIMEOUT)
+    timer_timeout: datetime.datetime | None = Field(alias="timerTimeout")
 
     async def set_timer(
-        self, timer_mode: str, duration: Optional[int] = None
+        self, timer_mode: str, duration: int | None = None
     ) -> aiohttp.ClientResponse:
         """Change the fan timer."""
         data: Dict[str, Any] = {
@@ -64,7 +56,7 @@ class FanTrait(CommandModel):
         }
         if duration:
             data["params"]["duration"] = f"{duration}s"
-        return await self._cmd.execute(data)
+        return await self.cmd.execute(data)
 
 
 @TRAIT_MAP.register()
@@ -73,7 +65,7 @@ class InfoTrait(TraitModel):
 
     NAME: Final = "sdm.devices.traits.Info"
 
-    custom_name: str | None = Field(alias=CUSTOM_NAME)
+    custom_name: str | None = Field(alias="customName")
     """Name of the device."""
 
 
@@ -83,7 +75,7 @@ class HumidityTrait(TraitModel):
 
     NAME: Final = "sdm.devices.traits.Humidity"
 
-    ambient_humidity_percent: float = Field(alias=AMBIENT_HUMIDITY_PERCENT)
+    ambient_humidity_percent: float = Field(alias="ambientHumidityPercent")
     """Percent humidity, measured at the device."""
 
 
@@ -93,5 +85,5 @@ class TemperatureTrait(TraitModel):
 
     NAME: Final = "sdm.devices.traits.Temperature"
 
-    ambient_temperature_celsius: float = Field(alias=AMBIENT_TEMPERATURE_CELSIUS)
+    ambient_temperature_celsius: float = Field(alias="ambientTemperatureCelsius")
     """Percent humidity, measured at the device."""

--- a/google_nest_sdm/traits.py
+++ b/google_nest_sdm/traits.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 from typing import Any, Dict, Mapping, Optional
 
 import aiohttp
-try:
-    from pydantic.v1 import BaseModel, root_validator
-except ImportError:
-    from pydantic import BaseModel, root_validator  # type: ignore
-
 
 from .auth import AbstractAuth
 from .diagnostics import Diagnostics
@@ -63,12 +58,19 @@ class CommandModel(TraitModel):
     _cmd: Command | None = None
     """Helper for executing commands"""
 
+    @property
+    def cmd(self) -> Command:
+        """Helper for executing commands, used internally by the trait"""
+        if not self._cmd:
+            raise ValueError("Device trait in invalid state")
+        return self._cmd
+
     class Config:
         extra = "allow"
         arbitrary_types_allowed = True
         fields = {
-            '_cmd': {
-                'exclude': True,
+            "_cmd": {
+                "exclude": True,
             }
         }
 
@@ -77,7 +79,7 @@ def _TraitsDict(
     traits: Mapping[str, Any], trait_map: Mapping[str, Any], cmd: Command
 ) -> Dict[str, Any]:
     d = {}
-    for (trait, trait_data) in traits.items():
+    for trait, trait_data in traits.items():
         if trait not in trait_map:
             continue
         cls = trait_map[trait]

--- a/google_nest_sdm/traits.py
+++ b/google_nest_sdm/traits.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from typing import Any, Dict, Mapping, Optional
 
 import aiohttp
+try:
+    from pydantic.v1 import BaseModel, root_validator
+except ImportError:
+    from pydantic import BaseModel, root_validator  # type: ignore
+
 
 from .auth import AbstractAuth
 from .diagnostics import Diagnostics
 from .registry import Registry
+from .model import TraitModel
 
 DEVICE_TRAITS = "traits"
+TRAITS = "traits"
 
 TRAIT_MAP = Registry()
 
@@ -50,6 +57,22 @@ class Command:
             return await resp.read()
 
 
+class CommandModel(TraitModel):
+    """Base model that supports commands."""
+
+    _cmd: Command | None = None
+    """Helper for executing commands"""
+
+    class Config:
+        extra = "allow"
+        arbitrary_types_allowed = True
+        fields = {
+            '_cmd': {
+                'exclude': True,
+            }
+        }
+
+
 def _TraitsDict(
     traits: Mapping[str, Any], trait_map: Mapping[str, Any], cmd: Command
 ) -> Dict[str, Any]:
@@ -58,7 +81,13 @@ def _TraitsDict(
         if trait not in trait_map:
             continue
         cls = trait_map[trait]
-        d[trait] = cls(trait_data, cmd)
+        if issubclass(cls, TraitModel):
+            obj = cls(**trait_data)
+            if hasattr(obj, "_cmd"):
+                obj._cmd = cmd
+        else:
+            obj = cls(trait_data, cmd)
+        d[trait] = obj
     return d
 
 


### PR DESCRIPTION
Use pydantic (v1) for parsing device traits to streamline code. Adds a separate subclass for handling traits that use commands.