### PR TITLE
Use pydantic for parsing thermostat traits

### DIFF
--- a/google_nest_sdm/thermostat_traits.py
+++ b/google_nest_sdm/thermostat_traits.py
@@ -93,7 +93,7 @@ class ThermostatTemperatureSetpointTrait(ThermostatHeatCoolTrait):
             "command": "sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat",
             "params": {"heatCelsius": heat},
         }
-        return await self._cmd.execute(data)
+        return await self.cmd.execute(data)
 
     async def set_cool(self, cool: float) -> aiohttp.ClientResponse:
         """Change the thermostat Eco mode."""
@@ -101,7 +101,7 @@ class ThermostatTemperatureSetpointTrait(ThermostatHeatCoolTrait):
             "command": "sdm.devices.commands.ThermostatTemperatureSetpoint.SetCool",
             "params": {"coolCelsius": cool},
         }
-        return await self._cmd.execute(data)
+        return await self.cmd.execute(data)
 
     async def set_range(self, heat: float, cool: float) -> aiohttp.ClientResponse:
         """Change the thermostat Eco mode."""
@@ -112,4 +112,4 @@ class ThermostatTemperatureSetpointTrait(ThermostatHeatCoolTrait):
                 "coolCelsius": cool,
             },
         }
-        return await self._cmd.execute(data)
+        return await self.cmd.execute(data)

--- a/google_nest_sdm/thermostat_traits.py
+++ b/google_nest_sdm/thermostat_traits.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Any, Final, List, Mapping, cast
+from abc import ABC
+from typing import Final
 
 import aiohttp
 try:
@@ -11,8 +11,7 @@ try:
 except ImportError:
     from pydantic import Field  # type: ignore
 
-from .traits import TRAIT_MAP, Command, CommandModel
-from .typing import cast_assert
+from .traits import TRAIT_MAP, CommandModel
 from .model import TraitModel
 
 STATUS: Final = "status"

--- a/google_nest_sdm/thermostat_traits.py
+++ b/google_nest_sdm/thermostat_traits.py
@@ -6,51 +6,41 @@ from abc import ABC, abstractmethod
 from typing import Any, Final, List, Mapping, cast
 
 import aiohttp
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field  # type: ignore
 
-from .traits import TRAIT_MAP, Command
+from .traits import TRAIT_MAP, Command, CommandModel
 from .typing import cast_assert
+from .model import TraitModel
 
 STATUS: Final = "status"
 AVAILABLE_MODES: Final = "availableModes"
 MODE: Final = "mode"
-HEAT_CELSIUS: Final = "heatCelsius"
-COOL_CELSIUS: Final = "coolCelsius"
 
 
-class ThermostatHeatCoolTrait(ABC):
+class ThermostatHeatCoolTrait(CommandModel, ABC):
     """Parent class for traits related to temperature set points."""
 
-    @property
-    @abstractmethod
-    def heat_celsius(self) -> float:
-        """Lowest temperature where Eco mode begins heating."""
+    heat_celsius: float = Field(alias="heatCelsius")
+    """Lowest temperature where thermostat begins heating."""
 
-    @property
-    @abstractmethod
-    def cool_celsius(self) -> float:
-        """Highest cooling temperature where Eco mode begins cooling."""
+    cool_celsius: float = Field(alias="coolCelsius")
+    """Highest cooling temperature where thermostat begins cooling."""
 
 
 @TRAIT_MAP.register()
 class ThermostatEcoTrait(ThermostatHeatCoolTrait):
     """This trait belongs to any device that has a sensor to measure temperature."""
 
-    NAME = "sdm.devices.traits.ThermostatEco"
+    NAME: Final = "sdm.devices.traits.ThermostatEco"
 
-    def __init__(self, data: Mapping[str, Any], cmd: Command):
-        """Initialize ThermostatEcoTrait."""
-        self._data = data
-        self._cmd = cmd
+    available_modes: list[str] = Field(alias="availableModes")
+    """List of supported Eco modes."""
 
-    @property
-    def available_modes(self) -> List[str]:
-        """List of supported Eco modes."""
-        return cast(List[str], self._data[AVAILABLE_MODES])
-
-    @property
-    def mode(self) -> str:
-        """Eco mode of the thermostat."""
-        return cast_assert(str, self._data[MODE])
+    mode: str = Field(alias="mode")
+    """Eco mode of the thermostat."""
 
     async def set_mode(self, mode: str) -> aiohttp.ClientResponse:
         """Change the thermostat Eco mode."""
@@ -58,55 +48,30 @@ class ThermostatEcoTrait(ThermostatHeatCoolTrait):
             "command": "sdm.devices.commands.ThermostatEco.SetMode",
             "params": {"mode": mode},
         }
-        return await self._cmd.execute(data)
-
-    @property
-    def heat_celsius(self) -> float:
-        """Lowest temperature where Eco mode begins heating."""
-        return cast(float, self._data[HEAT_CELSIUS])
-
-    @property
-    def cool_celsius(self) -> float:
-        """Highest cooling temperature where Eco mode begins cooling."""
-        return cast(float, self._data[COOL_CELSIUS])
+        return await self.cmd.execute(data)
 
 
 @TRAIT_MAP.register()
-class ThermostatHvacTrait:
+class ThermostatHvacTrait(TraitModel):
     """This trait belongs to devices that can report HVAC details."""
 
-    NAME = "sdm.devices.traits.ThermostatHvac"
+    NAME: Final = "sdm.devices.traits.ThermostatHvac"
 
-    def __init__(self, data: Mapping[str, Any], cmd: Command):
-        """Initialize ThermostatHvacTrait."""
-        self._data = data
-
-    @property
-    def status(self) -> List[str]:
-        """HVAC status of the thermostat."""
-        return cast(List[str], self._data[STATUS])
+    status: str = Field("status")
+    """HVAC status of the thermostat."""
 
 
 @TRAIT_MAP.register()
-class ThermostatModeTrait:
+class ThermostatModeTrait(CommandModel):
     """This trait belongs to devices that support different thermostat modes."""
 
-    NAME = "sdm.devices.traits.ThermostatMode"
+    NAME: Final = "sdm.devices.traits.ThermostatMode"
 
-    def __init__(self, data: Mapping[str, Any], cmd: Command):
-        """Initialize ThermostatModeTrait."""
-        self._data = data
-        self._cmd = cmd
+    available_modes: list[str] = Field(alias="availableModes")
+    """List of supported thermostat modes."""
 
-    @property
-    def available_modes(self) -> List[str]:
-        """List of supported thermostat modes."""
-        return cast(List[str], self._data[AVAILABLE_MODES])
-
-    @property
-    def mode(self) -> str:
-        """Mode of the thermostat."""
-        return cast_assert(str, self._data[MODE])
+    mode: str = Field(alias="mode")
+    """Mode of the thermostat."""
 
     async def set_mode(self, mode: str) -> aiohttp.ClientResponse:
         """Change the thermostat Eco mode."""
@@ -114,29 +79,14 @@ class ThermostatModeTrait:
             "command": "sdm.devices.commands.ThermostatMode.SetMode",
             "params": {"mode": mode},
         }
-        return await self._cmd.execute(data)
+        return await self.cmd.execute(data)
 
 
 @TRAIT_MAP.register()
 class ThermostatTemperatureSetpointTrait(ThermostatHeatCoolTrait):
     """This trait belongs to devices that support setting target temperature."""
 
-    NAME = "sdm.devices.traits.ThermostatTemperatureSetpoint"
-
-    def __init__(self, data: Mapping[str, Any], cmd: Command):
-        """Initialize ThermostatTemperatureSetpointTrait."""
-        self._data = data
-        self._cmd = cmd
-
-    @property
-    def heat_celsius(self) -> float:
-        """Lowest temperature where Eco mode begins heating."""
-        return cast(float, self._data[HEAT_CELSIUS])
-
-    @property
-    def cool_celsius(self) -> float:
-        """Highest cooling temperature where Eco mode begins cooling."""
-        return cast(float, self._data[COOL_CELSIUS])
+    NAME: Final = "sdm.devices.traits.ThermostatTemperatureSetpoint"
 
     async def set_heat(self, heat: float) -> aiohttp.ClientResponse:
         """Change the thermostat Eco mode."""


### PR DESCRIPTION
Use pydantic for parsing thermostat traits to reduce amount of code and enforce consistency.