### PR TITLE
Run tests with pydantic v1 in addition to v2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=google_nest_sdm --cov-report=xml
+
+    - name: Test with pytest (pydantic v1)
+      run: |
+        pip3 install pydantic==1.10.3
+        pytest --cov=google_nest_sdm --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3.1.4
       with:


### PR DESCRIPTION
Add a separate line in the workflow to also run tests with pydantic v1 to ensure compatibility shims continue to work.