### PR TITLE
Filter test warnings in google pubsub dependencies

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,7 @@ log_level = DEBUG
 filterwarnings =
     ignore:.*decorator is deprecated since Python 3.8, use "async def" instead
     ignore:.*Call to deprecated create function .*Descriptor.*
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources
+    ignore:.*declare_namespace\(':DeprecationWarning
 asyncio_mode = auto
 log_cli = true


### PR DESCRIPTION
Filter test warnings in google pubsub dependencies on deprecated libraries in google auth.