### PR TITLE
Drop invalid parentRelations responses

### DIFF
--- a/google_nest_sdm/device.py
+++ b/google_nest_sdm/device.py
@@ -26,7 +26,7 @@ class ParentRelation(BaseModel):
     """Represents the parent structure/room of the current resource."""
 
     parent: str
-    display_name: str = Field(alias="displayName") #, default="")
+    display_name: str = Field(alias="displayName")
 
 
 class DeviceTraits(TraitModel):

--- a/google_nest_sdm/device.py
+++ b/google_nest_sdm/device.py
@@ -7,9 +7,9 @@ import logging
 from typing import Any, Awaitable, Callable
 
 try:
-    from pydantic.v1 import BaseModel, Field
+    from pydantic.v1 import BaseModel, Field, root_validator
 except ImportError:
-    from pydantic import BaseModel, Field  # type: ignore
+    from pydantic import BaseModel, Field, root_validator # type: ignore
 
 from . import camera_traits, device_traits, doorbell_traits, thermostat_traits
 from .auth import AbstractAuth
@@ -26,7 +26,7 @@ class ParentRelation(BaseModel):
     """Represents the parent structure/room of the current resource."""
 
     parent: str
-    display_name: str = Field(alias="displayName")
+    display_name: str = Field(alias="displayName") #, default="")
 
 
 class DeviceTraits(TraitModel):
@@ -246,6 +246,17 @@ class Device(DeviceTraits):
             "data": redact_data(self.raw_data),
             **self._diagnostics.as_dict(),
         }
+
+    @root_validator(pre=True)
+    def _parent_relations(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Ignore invalid parentRelations."""
+        if not (relations := values.get("parentRelations")):
+            return values
+        values["parentRelations"] = [
+            relation for relation in relations if "parent" in relation and "displayName" in relation 
+        ]
+        return values
+
 
     _EXCLUDE_FIELDS = (
         set({"_auth", "_callbacks", "_cmd", "_diagnostics", "_event_media_manager"})

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -60,6 +60,20 @@ def test_empty_parent_relations(
     assert {} == device.parent_relations
 
 
+def test_invalid_parent_relations(
+    fake_device: Callable[[Dict[str, Any]], Device]
+) -> None:
+    """Invalid parentRelations should be ignored."""
+    device = fake_device(
+        {
+            "name": "my/device/name",
+            "parentRelations": [{}],
+        }
+    )
+    assert "my/device/name" == device.name
+    assert {} == device.parent_relations
+
+
 def test_parent_relation(fake_device: Callable[[Dict[str, Any]], Device]) -> None:
     device = fake_device(
         {


### PR DESCRIPTION
Drop invalid parentRelations responses to avoid parse failures.