### PR TITLE
Add a hack to detect invalid server messages and trigger a device state refresh

### DIFF
--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -565,8 +565,8 @@ class GoogleNestSubscriber:
 
 def _is_invalid_thermostat_trait_update(event: EventMessage) -> bool:
     """Return true if this is an invalid thermostat trait update."""
-    return (
-        event.resource_update_traits
+    if (
+        event.resource_update_traits is not None
         and (
             thermostat_mode := event.resource_update_traits.get(
                 "sdm.devices.traits.ThermostatMode"
@@ -574,7 +574,9 @@ def _is_invalid_thermostat_trait_update(event: EventMessage) -> bool:
         )
         and (available_modes := thermostat_mode.get("availableModes")) is not None
         and available_modes == ["OFF"]
-    )
+    ):
+        return True
+    return False
 
 
 async def _hack_refresh_devices(

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -24,7 +24,12 @@ from .device_manager import DeviceManager
 from .diagnostics import SUBSCRIBER_DIAGNOSTICS as DIAGNOSTICS
 from .event import EventMessage
 from .event_media import CachePolicy
-from .exceptions import AuthException, ConfigurationException, SubscriberException, ApiException
+from .exceptions import (
+    AuthException,
+    ConfigurationException,
+    SubscriberException,
+    ApiException,
+)
 from .google_nest_api import GoogleNestAPI
 
 __all__ = [
@@ -545,27 +550,41 @@ class GoogleNestSubscriber:
         ):
             device_manager = self._device_manager_task.result()
             if _is_invalid_thermostat_trait_update(event):
-                _LOGGER.debug("Ignoring event with invalid update traits; Refreshing devices: %s", event.resource_update_traits)
+                _LOGGER.debug(
+                    "Ignoring event with invalid update traits; Refreshing devices: %s",
+                    event.resource_update_traits,
+                )
                 await _hack_refresh_devices(self._api, device_manager)
             else:
                 await device_manager.async_handle_event(event)
             message.ack()
-    
+
         ack_latency_ms = int((time.time() - recv) * 1000)
         DIAGNOSTICS.elapsed("message_acked", ack_latency_ms)
-        
+
 
 def _is_invalid_thermostat_trait_update(event: EventMessage) -> bool:
     """Return true if this is an invalid thermostat trait udpate."""
-    return event.resource_update_traits and (thermostat_mode := event.resource_update_traits.get("sdm.devices.traits.ThermostatMode")) and (available_modes := thermostat_mode.get("availableModes")) == ["OFF"]
+    return (
+        event.resource_update_traits
+        and (
+            thermostat_mode := event.resource_update_traits.get(
+                "sdm.devices.traits.ThermostatMode"
+            )
+        )
+        and (available_modes := thermostat_mode.get("availableModes")) is not None
+        and available_modes == ["OFF"]
+    )
 
 
-async def _hack_refresh_devices(api: GoogleNestAPI, device_manager: DeviceManager) -> None:
+async def _hack_refresh_devices(
+    api: GoogleNestAPI, device_manager: DeviceManager
+) -> None:
     """Update the device manager with refreshed devices from the API."""
     DIAGNOSTICS.increment("invalid-thermostat-update")
     try:
         devices = await api.async_get_devices()
-    except ApiException as err:
+    except ApiException:
         DIAGNOSTICS.increment("invalid-thermostat-update-refresh-failure")
         _LOGGER.debug("Failed to refresh devices after invalid message")
     else:

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -564,7 +564,7 @@ class GoogleNestSubscriber:
 
 
 def _is_invalid_thermostat_trait_update(event: EventMessage) -> bool:
-    """Return true if this is an invalid thermostat trait udpate."""
+    """Return true if this is an invalid thermostat trait update."""
     return (
         event.resource_update_traits
         and (

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -650,22 +650,22 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
 
     device_id = device_handler.add_device(
         traits={
-                "sdm.devices.traits.ThermostatEco" : {
-                    "availableModes" : ["MANUAL_ECO", "OFF"],
-                    "mode" : "MANUAL_ECO",
-                    "heatCelsius" : 20.0,
-                    "coolCelsius" : 22.0
-                },
-                "sdm.devices.traits.ThermostatHvac": {
-                    "status": "HEATING",
-                },
-                "sdm.devices.traits.ThermostatMode" : {
-                    "availableModes" : ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                    "mode" : "HEAT"
-                },
-                "sdm.devices.traits.ThermostatTemperatureSetpoint" : {
-                    "heatCelsius" : 20.0,
-                },
+            "sdm.devices.traits.ThermostatEco": {
+                "availableModes": ["MANUAL_ECO", "OFF"],
+                "mode": "MANUAL_ECO",
+                "heatCelsius": 20.0,
+                "coolCelsius": 22.0,
+            },
+            "sdm.devices.traits.ThermostatHvac": {
+                "status": "HEATING",
+            },
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 20.0,
+            },
         }
     )
     structure_handler.add_structure()
@@ -674,7 +674,7 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
     subscriber.cache_policy.event_cache_size = 5
     await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
-    
+
     device = device_manager.devices.get(device_id)
     assert device
 
@@ -704,27 +704,30 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
     trait = device_handler.devices[0]["traits"]["sdm.devices.traits.ThermostatEco"]
     trait["heatCelsius"] = 19.0
 
-    # Simulate a case where the nest publisher sends an invalid message. This 
+    # Simulate a case where the nest publisher sends an invalid message. This
     # will be ignored and will trigger another state refresh.
     await subscriber_factory.async_push_event(
-            {
-                "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
-                "timestamp": "2019-01-01T00:00:01Z",
-                "resourceUpdate": {
-                    "name": device.name,
-                    "traits": {
-                        "sdm.devices.traits.ThermostatMode": {"mode": "OFF", "availableModes": ["OFF"]},
-                        "sdm.devices.traits.ThermostatEco": {
-                            "availableModes": ["OFF", "MANUAL_ECO"],
-                            "mode": "OFF", 
-                            "heatCelsius": 0.0,
-                            "coolCelsius": 0.0
-                        },
-                        "sdm.devices.traits.ThermostatTemperatureSetpoint": {}
+        {
+            "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+            "timestamp": "2019-01-01T00:00:01Z",
+            "resourceUpdate": {
+                "name": device.name,
+                "traits": {
+                    "sdm.devices.traits.ThermostatMode": {
+                        "mode": "OFF",
+                        "availableModes": ["OFF"],
                     },
+                    "sdm.devices.traits.ThermostatEco": {
+                        "availableModes": ["OFF", "MANUAL_ECO"],
+                        "mode": "OFF",
+                        "heatCelsius": 0.0,
+                        "coolCelsius": 0.0,
+                    },
+                    "sdm.devices.traits.ThermostatTemperatureSetpoint": {},
                 },
-                "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
-            }
+            },
+            "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+        }
     )
 
     device = device_manager.devices.get(device_id)
@@ -750,7 +753,6 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
     trait = device.traits.get("sdm.devices.traits.ThermostatTemperatureSetpoint")
     assert trait
     assert trait.heat_celsius == 20.0
-
 
 
 def test_api_env_prod() -> None:

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -639,6 +639,120 @@ async def test_subscribe_thread_update_new_events(
     subscriber.stop_async()
 
 
+async def test_refresh_hack_on_invalid_thermostat_traits(
+    app: aiohttp.web.Application,
+    device_handler: DeviceHandler,
+    structure_handler: StructureHandler,
+    subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
+    subscriber_factory: FakeSubscriberFactory,
+) -> None:
+    """Test that when invalid thermostat traits are ignored and triggers a refresh."""
+
+    device_id = device_handler.add_device(
+        traits={
+                "sdm.devices.traits.ThermostatEco" : {
+                    "availableModes" : ["MANUAL_ECO", "OFF"],
+                    "mode" : "MANUAL_ECO",
+                    "heatCelsius" : 20.0,
+                    "coolCelsius" : 22.0
+                },
+                "sdm.devices.traits.ThermostatHvac": {
+                    "status": "HEATING",
+                },
+                "sdm.devices.traits.ThermostatMode" : {
+                    "availableModes" : ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                    "mode" : "HEAT"
+                },
+                "sdm.devices.traits.ThermostatTemperatureSetpoint" : {
+                    "heatCelsius" : 20.0,
+                },
+        }
+    )
+    structure_handler.add_structure()
+
+    subscriber = await subscriber_client()
+    subscriber.cache_policy.event_cache_size = 5
+    await subscriber.start_async()
+    device_manager = await subscriber.async_get_device_manager()
+    
+    device = device_manager.devices.get(device_id)
+    assert device
+
+    # Verify initial device state
+    trait = device.traits.get("sdm.devices.traits.ThermostatEco")
+    assert trait
+    assert set(trait.available_modes) == set(["MANUAL_ECO", "OFF"])
+    assert trait.mode == "MANUAL_ECO"
+    assert trait.heat_celsius == 20.0
+    assert trait.cool_celsius == 22.0
+
+    trait = device.traits.get("sdm.devices.traits.ThermostatMode")
+    assert trait
+    assert set(trait.available_modes) == set(["HEAT", "COOL", "HEATCOOL", "OFF"])
+    assert trait.mode == "HEAT"
+
+    trait = device.traits.get("sdm.devices.traits.ThermostatHvac")
+    assert trait
+    assert trait.status == "HEATING"
+
+    trait = device.traits.get("sdm.devices.traits.ThermostatTemperatureSetpoint")
+    assert trait
+    assert trait.heat_celsius == 20.0
+
+    # Update the state on the server to something arbitrary. Later we will verify
+    # that a request was made to get the latest server state.
+    trait = device_handler.devices[0]["traits"]["sdm.devices.traits.ThermostatEco"]
+    trait["heatCelsius"] = 19.0
+
+    # Simulate a case where the nest publisher sends an invalid message. This 
+    # will be ignored and will trigger another state refresh.
+    await subscriber_factory.async_push_event(
+            {
+                "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+                "timestamp": "2019-01-01T00:00:01Z",
+                "resourceUpdate": {
+                    "name": device.name,
+                    "traits": {
+                        "sdm.devices.traits.ThermostatMode": {"mode": "OFF", "availableModes": ["OFF"]},
+                        "sdm.devices.traits.ThermostatEco": {
+                            "availableModes": ["OFF", "MANUAL_ECO"],
+                            "mode": "OFF", 
+                            "heatCelsius": 0.0,
+                            "coolCelsius": 0.0
+                        },
+                        "sdm.devices.traits.ThermostatTemperatureSetpoint": {}
+                    },
+                },
+                "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+            }
+    )
+
+    device = device_manager.devices.get(device_id)
+    assert device
+
+    # Verify the invalid message is dropped and the server update is reflected
+    trait = device.traits.get("sdm.devices.traits.ThermostatEco")
+    assert trait
+    assert set(trait.available_modes) == set(["MANUAL_ECO", "OFF"])
+    assert trait.mode == "MANUAL_ECO"
+    assert trait.heat_celsius == 19.0  # State update reflected
+    assert trait.cool_celsius == 22.0
+
+    trait = device.traits.get("sdm.devices.traits.ThermostatMode")
+    assert trait
+    assert set(trait.available_modes) == set(["HEAT", "COOL", "HEATCOOL", "OFF"])
+    assert trait.mode == "HEAT"
+
+    trait = device.traits.get("sdm.devices.traits.ThermostatHvac")
+    assert trait
+    assert trait.status == "HEATING"
+
+    trait = device.traits.get("sdm.devices.traits.ThermostatTemperatureSetpoint")
+    assert trait
+    assert trait.heat_celsius == 20.0
+
+
+
 def test_api_env_prod() -> None:
     env = get_api_env("prod")
     assert (


### PR DESCRIPTION
Add a hack to detect invalid server messages and trigger a device state refresh.

Nest servers sometimes publish invalid state changes due to a server bug. This bug has been persistent enough that it 
seems like we need to workaround this and ignore the messages.

Users report invalid messages published look like the following:
```json
{'sdm.devices.traits.ThermostatMode': {'mode': 'OFF', 'availableModes': ['OFF']},
'sdm.devices.traits.ThermostatEco': {'availableModes': ['OFF', 'MANUAL_ECO'], 'mode': 'OFF', 
'heatCelsius': 0.0, 'coolCelsius': 0.0}, 'sdm.devices.traits.ThermostatTemperatureSetpoint': {}}}
```

We detect this by looking for a `ThermostatMode` with only a limited set of `availableModes` and throw away the entire update. We also trigger a refresh of the devices list from the server to get the current actual state.

Meant to workaround symptoms of:
https://github.com/home-assistant/core/issues/113163