### PR TITLE
Replace use of pydantic with mashumaro

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,10 +29,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=google_nest_sdm --cov-report=xml
-    - name: Test with pytest (pydantic v1)
-      run: |
-        pip3 install pydantic==1.10.3
-        pytest --cov=google_nest_sdm --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4.1.1
       with:

--- a/google_nest_sdm/device.py
+++ b/google_nest_sdm/device.py
@@ -287,11 +287,11 @@ class Device(TraitTypes):
         # the new fields merged in.
         parsed_traits = TraitTypes.parse_trait_object({TRAITS: traits})
         for trait_field in fields(parsed_traits):
-            if (alias := trait_field.metadata.get("alias")) is None:
-                continue
-            if not alias.startswith(SDM_PREFIX):
-                continue
-            if not (new := getattr(parsed_traits, trait_field.name)):
+            if (
+                (alias := trait_field.metadata.get("alias")) is None
+                or not alias.startswith(SDM_PREFIX)
+                or not (new := getattr(parsed_traits, trait_field.name))
+            ):
                 continue
             # Discard updates to traits that are newer than the update
             if (

--- a/google_nest_sdm/device.py
+++ b/google_nest_sdm/device.py
@@ -336,11 +336,6 @@ class Device(TraitTypes):
             **self._diagnostics.as_dict(),
         }
 
-    _EXCLUDE_FIELDS = (
-        set({"_auth", "_callbacks", "_cmd", "_diagnostics", "_event_media_manager"})
-        | TraitDataClass._EXCLUDE_FIELDS
-    )
-
     class Config(TraitTypes.Config):
         serialization_strategy = {
             list[ParentRelation]: ParentRelationsSerializationStrategy(),

--- a/google_nest_sdm/device_manager.py
+++ b/google_nest_sdm/device_manager.py
@@ -92,8 +92,10 @@ class DeviceManager:
             # Device moved to a room
             assert relation.subject
             device.create_relation(
-                ParentRelation(
-                    parent=relation.subject,
-                    displayName=self._structure_name(relation.subject),
+                ParentRelation.from_dict(
+                    {
+                        "parent": relation.subject,
+                        "displayName": self._structure_name(relation.subject),
+                    }
                 )
             )

--- a/google_nest_sdm/device_traits.py
+++ b/google_nest_sdm/device_traits.py
@@ -1,22 +1,20 @@
 """Library for traits about devices."""
 
 import datetime
-from typing import Any, Dict, Final
-
-try:
-    from pydantic.v1 import BaseModel, Field
-except ImportError:
-    from pydantic import BaseModel, Field  # type: ignore
+from typing import Any, Dict, ClassVar
+from dataclasses import dataclass, field
 
 import aiohttp
+from mashumaro import field_options, DataClassDictMixin
 
-from .traits import CommandModel
+from .traits import CommandDataClass, TraitType
 
 
-class ConnectivityTrait(BaseModel):
+@dataclass
+class ConnectivityTrait(DataClassDictMixin):
     """This trait belongs to any device that has connectivity information."""
 
-    NAME: Final = "sdm.devices.traits.Connectivity"
+    NAME: ClassVar[TraitType] = TraitType.CONNECTIVITY
 
     status: str
     """Device connectivity status.
@@ -26,19 +24,24 @@ class ConnectivityTrait(BaseModel):
     """
 
 
-class FanTrait(CommandModel):
+@dataclass
+class FanTrait(DataClassDictMixin, CommandDataClass):
     """This trait belongs to any device that can control the fan."""
 
-    NAME: Final = "sdm.devices.traits.Fan"
+    NAME: ClassVar[TraitType] = TraitType.FAN
 
-    timer_mode: str | None = Field(alias="timerMode")
+    timer_mode: str | None = field(
+        metadata=field_options(alias="timerMode"), default=None
+    )
     """Timer mode for the fan.
 
     Return:
         "ON", "OFF"
     """
 
-    timer_timeout: datetime.datetime | None = Field(alias="timerTimeout")
+    timer_timeout: datetime.datetime | None = field(
+        metadata=field_options(alias="timerTimeout"), default=None
+    )
 
     async def set_timer(
         self, timer_mode: str, duration: int | None = None
@@ -55,28 +58,37 @@ class FanTrait(CommandModel):
         return await self.cmd.execute(data)
 
 
-class InfoTrait(BaseModel):
+@dataclass
+class InfoTrait(DataClassDictMixin):
     """This trait belongs to any device for device-related information."""
 
-    NAME: Final = "sdm.devices.traits.Info"
+    NAME: ClassVar[TraitType] = TraitType.INFO
 
-    custom_name: str | None = Field(alias="customName")
+    custom_name: str | None = field(
+        metadata=field_options(alias="customName"), default=None
+    )
     """Name of the device."""
 
 
-class HumidityTrait(BaseModel):
+@dataclass
+class HumidityTrait(DataClassDictMixin):
     """This trait belongs to any device that has a sensor to measure humidity."""
 
-    NAME: Final = "sdm.devices.traits.Humidity"
+    NAME: ClassVar[TraitType] = TraitType.HUMIDITY
 
-    ambient_humidity_percent: float = Field(alias="ambientHumidityPercent")
+    ambient_humidity_percent: float = field(
+        metadata=field_options(alias="ambientHumidityPercent")
+    )
     """Percent humidity, measured at the device."""
 
 
-class TemperatureTrait(BaseModel):
+@dataclass
+class TemperatureTrait(DataClassDictMixin):
     """This trait belongs to any device that has a sensor to measure temperature."""
 
-    NAME: Final = "sdm.devices.traits.Temperature"
+    NAME: ClassVar[TraitType] = TraitType.TEMPERATURE
 
-    ambient_temperature_celsius: float = Field(alias="ambientTemperatureCelsius")
+    ambient_temperature_celsius: float = field(
+        metadata=field_options(alias="ambientTemperatureCelsius")
+    )
     """Percent humidity, measured at the device."""

--- a/google_nest_sdm/doorbell_traits.py
+++ b/google_nest_sdm/doorbell_traits.py
@@ -2,25 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
-from typing import Final
+from typing import ClassVar
 
-try:
-    from pydantic.v1 import BaseModel
-except ImportError:
-    from pydantic import BaseModel  # type: ignore
-
-from .event import DoorbellChimeEvent
+from .event import DoorbellChimeEvent, EventType
+from .traits import TraitType
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DoorbellChimeTrait(BaseModel):
+@dataclass
+class DoorbellChimeTrait:
     """For any device that supports a doorbell chime and related press events."""
 
-    NAME: Final = "sdm.devices.traits.DoorbellChime"
-    EVENT_NAME: Final[str] = DoorbellChimeEvent.NAME
-
-    class Config:
-        extra = "allow"
-        arbitrary_types_allowed = True
+    NAME: ClassVar[TraitType] = TraitType.DOORBELL_CHIME
+    EVENT_NAME: ClassVar[EventType] = DoorbellChimeEvent.NAME

--- a/google_nest_sdm/event.py
+++ b/google_nest_sdm/event.py
@@ -2,32 +2,23 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import base64
 import binascii
+from dataclasses import dataclass, field
 import datetime
+from enum import StrEnum
 import hashlib
 import json
 import logging
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Final
+import traceback
+from typing import Any, Iterable, Mapping, ClassVar
 
-try:
-    from pydantic.v1 import (
-        BaseModel,
-        Field,
-        root_validator,
-        validate_arguments,
-        validator,
-    )
-except ImportError:
-    from pydantic import (  # type: ignore
-        BaseModel,
-        Field,
-        root_validator,
-        validate_arguments,
-        validator,
-    )
+from mashumaro import DataClassDictMixin, field_options
+from mashumaro.config import (
+    BaseConfig,
+)
+from mashumaro.types import SerializationStrategy
 
 from .auth import AbstractAuth
 from .exceptions import DecodeException
@@ -67,12 +58,22 @@ EVENT_MAP = Registry()
 _LOGGER = logging.getLogger(__name__)
 
 
+class EventType(StrEnum):
+    """Types of events."""
+
+    CAMERA_MOTION = "sdm.devices.events.CameraMotion.Motion"
+    CAMERA_PERSON = "sdm.devices.events.CameraPerson.Person"
+    CAMERA_SOUND = "sdm.devices.events.CameraSound.Sound"
+    DOORBELL_CHIME = "sdm.devices.events.DoorbellChime.Chime"
+    CAMERA_CLIP_PREVIEW = "sdm.devices.events.CameraClipPreview.ClipPreview"
+
+
 class EventProcessingError(Exception):
     """Raised when there was an error handling an event."""
 
 
-@dataclass
-class EventImageContentType:
+@dataclass(frozen=True)
+class EventImageContentType(DataClassDictMixin):
     """Event image content type."""
 
     content_type: str
@@ -82,7 +83,7 @@ class EventImageContentType:
         return self.content_type
 
 
-class EventImageType:
+class EventImageType(ABC):
     IMAGE = EventImageContentType("image/jpeg")
     CLIP_PREVIEW = EventImageContentType("video/mp4")
     IMAGE_PREVIEW = EventImageContentType("image/gif")
@@ -104,8 +105,8 @@ class EventImageType:
 class EventToken:
     """Identifier for a unique event."""
 
-    event_session_id: str = Field(alias="eventSessionId")
-    event_id: str = Field(alias="eventId")
+    event_session_id: str = field(metadata=field_options(alias="eventSessionId"))
+    event_id: str = field(metadata=field_options(alias="eventId"))
 
     def encode(self) -> str:
         """Encode the event token as a serialized string."""
@@ -137,28 +138,33 @@ class EventToken:
         )
 
 
-class ImageEventBase(BaseModel, ABC):
+class EventImageTypeSerializationStrategy(SerializationStrategy):
+
+    def serialize(self, value: EventImageContentType) -> str:
+        return value.content_type
+
+    def deserialize(self, value: str) -> EventImageContentType:
+        return EventImageType.from_string(value)
+
+
+@dataclass
+class ImageEventBase(DataClassDictMixin, ABC):
     """Base class for all image related event types."""
 
-    event_id: str = Field(alias="eventId")
+    event_session_id: str = field(metadata=field_options(alias="eventSessionId"))
     """ID used to associate separate messages with a single event."""
-
-    event_session_id: str = Field(alias="eventSessionId")
-    """ID used to associate separate messages with a single event."""
-
-    zones: list[str] = Field(default_factory=list)
-    """List of zones for the event."""
 
     timestamp: datetime.datetime
     """Timestamp when the event occurred."""
 
-    event_image_type: EventImageContentType
+    event_id: str = field(metadata=field_options(alias="eventId"), default="")
+    """ID used to associate separate messages with a single event."""
+
+    event_image_type: EventImageContentType = field(default=EventImageType.IMAGE)
     """Type of the event."""
 
-    def __init__(self, data: Mapping[str, Any], timestamp: datetime.datetime) -> None:
-        """Initialize EventBase."""
-        super().__init__(**data, timestamp=timestamp)
-        self._data = data
+    zones: list[str] = field(default_factory=list)
+    """List of zones for the event."""
 
     @property
     def event_token(self) -> str:
@@ -168,7 +174,7 @@ class ImageEventBase(BaseModel, ABC):
 
     @property
     @abstractmethod
-    def event_type(self) -> str:
+    def event_type(self) -> EventType:
         """The type of event."""
 
     @property
@@ -183,21 +189,20 @@ class ImageEventBase(BaseModel, ABC):
         return self.expires_at < now
 
     def as_dict(self) -> dict[str, Any]:
-        """Return as a dict form that can be serialized."""
+        """Return as a dict form that can be serialized for persistence."""
         return {
             "event_type": self.event_type,
-            "event_data": self._data,
+            "event_data": self.to_dict(),
             "timestamp": self.timestamp.isoformat(),
             "event_image_type": str(self.event_image_type),
         }
 
     @staticmethod
-    def from_dict(data: dict[str, Any]) -> ImageEventBase | None:
-        """Parse from a serialized dictionary."""
+    def parse_event_dict(data: dict[str, Any]) -> ImageEventBase | None:
+        """Parse from a persisted serialized dictionary."""
         event_type = data["event_type"]
         event_data = data["event_data"]
-        timestamp = datetime.datetime.fromisoformat(data["timestamp"])
-        event = _BuildEvent(event_type, event_data, timestamp)
+        event = _BuildEvent(event_type, event_data)
         if event and "event_image_type" in data:
             event.event_image_type = EventImageType.from_string(
                 data["event_image_type"]
@@ -207,70 +212,100 @@ class ImageEventBase(BaseModel, ABC):
     def __repr__(self) -> str:
         return "<ImageEventBase " + str(self.as_dict()) + ">"
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = "allow"
+    class Config(BaseConfig):
+        serialization_strategy = {
+            EventImageContentType: EventImageTypeSerializationStrategy(),
+        }
+        code_generation_options = [
+            "TO_DICT_ADD_BY_ALIAS_FLAG",
+            "TO_DICT_ADD_OMIT_NONE_FLAG",
+        ]
+        allow_deserialization_not_by_alias = True
 
 
 @EVENT_MAP.register()
+@dataclass
 class CameraMotionEvent(ImageEventBase):
     """Motion has been detected by the camera."""
 
-    NAME: Final = "sdm.devices.events.CameraMotion.Motion"
-    event_type: Final = "sdm.devices.events.CameraMotion.Motion"
-    event_image_type = EventImageType.IMAGE
+    NAME: ClassVar[EventType] = EventType.CAMERA_MOTION
+    event_image_type: EventImageContentType = field(default=EventImageType.IMAGE)
+
+    @property
+    def event_type(self) -> EventType:
+        """The type of event."""
+        return EventType.CAMERA_MOTION
 
 
 @EVENT_MAP.register()
+@dataclass
 class CameraPersonEvent(ImageEventBase):
     """A person has been detected by the camera."""
 
-    NAME: Final = "sdm.devices.events.CameraPerson.Person"
-    event_type: Final = "sdm.devices.events.CameraPerson.Person"
-    event_image_type = EventImageType.IMAGE
+    NAME: ClassVar[EventType] = EventType.CAMERA_PERSON
+    event_image_type: EventImageContentType = field(default=EventImageType.IMAGE)
+
+    @property
+    def event_type(self) -> EventType:
+        """The type of event."""
+        return EventType.CAMERA_PERSON
 
 
 @EVENT_MAP.register()
+@dataclass
 class CameraSoundEvent(ImageEventBase):
     """Sound has been detected by the camera."""
 
-    NAME: Final = "sdm.devices.events.CameraSound.Sound"
-    event_type: Final = "sdm.devices.events.CameraSound.Sound"
-    event_image_type = EventImageType.IMAGE
+    NAME: ClassVar[EventType] = EventType.CAMERA_SOUND
+    event_image_type: EventImageContentType = field(default=EventImageType.IMAGE)
+
+    @property
+    def event_type(self) -> EventType:
+        """The type of event."""
+        return EventType.CAMERA_SOUND
 
 
 @EVENT_MAP.register()
+@dataclass
 class DoorbellChimeEvent(ImageEventBase):
     """The doorbell has been pressed."""
 
-    NAME: Final = "sdm.devices.events.DoorbellChime.Chime"
-    event_type: Final = "sdm.devices.events.DoorbellChime.Chime"
-    event_image_type = EventImageType.IMAGE
+    NAME: ClassVar[EventType] = EventType.DOORBELL_CHIME
+    event_image_type: EventImageContentType = field(default=EventImageType.IMAGE)
+
+    @property
+    def event_type(self) -> EventType:
+        """The type of event."""
+        return EventType.DOORBELL_CHIME
 
 
 @EVENT_MAP.register()
+@dataclass
 class CameraClipPreviewEvent(ImageEventBase):
     """A video clip is available for preview, without extra download."""
 
-    NAME: Final = "sdm.devices.events.CameraClipPreview.ClipPreview"
-    event_type: Final = "sdm.devices.events.CameraClipPreview.ClipPreview"
-    event_image_type = EventImageType.CLIP_PREVIEW
+    NAME: ClassVar[EventType] = EventType.CAMERA_CLIP_PREVIEW
+    event_image_type: EventImageContentType = field(default=EventImageType.CLIP_PREVIEW)
 
-    preview_url: str = Field(alias="previewUrl")
+    preview_url: str = field(metadata=field_options(alias="previewUrl"), default="")
     """A url 10 second frame video file in mp4 format."""
 
-    @root_validator(pre=True)
-    def validate_event_id(cls, val: dict[str, Any]) -> dict[str, Any]:
-        """Use a URL hash as the event id.
+    @property
+    def event_type(self) -> EventType:
+        """The type of event."""
+        return EventType.CAMERA_CLIP_PREVIEW
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
+        """Validate the event id to use a URL hash as the event id.
 
         Since clip preview events already have a url associated with them,
         we don't have an event id for downloading the image.
         """
-        if "previewUrl" not in val:
+        if not (preview_url := d.get("previewUrl", d.get("preview_url"))):
             raise ValueError("missing required field previewUrl")
-        url = val["previewUrl"]
-        val["eventId"] = hashlib.blake2b(url.encode()).hexdigest()
-        return val
+        d["eventId"] = hashlib.blake2b(preview_url.encode()).hexdigest()
+        return d
 
     @property
     def expires_at(self) -> datetime.datetime:
@@ -280,7 +315,8 @@ class CameraClipPreviewEvent(ImageEventBase):
         )
 
 
-class RelationUpdate(BaseModel):
+@dataclass
+class RelationUpdate(DataClassDictMixin):
     """Represents a relational update for a resource."""
 
     type: str
@@ -293,27 +329,19 @@ class RelationUpdate(BaseModel):
     """Resource that triggered the event."""
 
 
-def _BuildEvents(
-    events: Mapping[str, Any],
-    timestamp: datetime.datetime,
-) -> dict[str, ImageEventBase]:
-    """Build a trait map out of a response dict."""
-    result = {}
-    for event_type, event_data in events.items():
-        image_event = _BuildEvent(event_type, event_data, timestamp)
-        if not image_event:
-            continue
-        result[event_type] = image_event
-    return result
-
-
 def _BuildEvent(
-    event_type: str, event_data: Mapping[str, Any], timestamp: datetime.datetime
+    event_type: str, event_data: Mapping[str, Any]
 ) -> ImageEventBase | None:
     if event_type not in EVENT_MAP:
+        _LOGGER.debug("Event type %s not found (%s)", event_type, EVENT_MAP.keys())
         return None
     cls = EVENT_MAP[event_type]
-    return cls(event_data, timestamp)  # type: ignore
+    try:
+        return cls.from_dict(event_data)  # type: ignore
+    except Exception as err:
+        traceback.print_exc()
+        _LOGGER.debug("Failed to parse event: %s (event_data=%s)", err, event_data)
+        raise err
 
 
 def session_event_image_type(events: Iterable[ImageEventBase]) -> EventImageContentType:
@@ -324,46 +352,64 @@ def session_event_image_type(events: Iterable[ImageEventBase]) -> EventImageCont
     return EventImageType.IMAGE
 
 
-@validate_arguments
-def _validate_datetime(value: datetime.datetime) -> datetime.datetime:
-    return value
+class UpdateEventsSerializationStrategy(SerializationStrategy, use_annotations=True):
+    """Parser to ignore invalid parent relations."""
+
+    def serialize(self, value: dict[str, ImageEventBase]) -> dict[str, Any]:
+        return {k: v.to_dict(by_alias=True) for k, v in value.items()}
+
+    def deserialize(self, value: dict[str, Any]) -> dict[str, ImageEventBase]:
+        result = {}
+        for event_type, event_data in value.items():
+            _LOGGER.debug("Deserializing event type %s", event_type)
+            image_event = _BuildEvent(event_type, event_data)
+            if not image_event:
+                continue
+            result[event_type] = image_event
+        return result
 
 
-class EventMessage(BaseModel):
+@dataclass
+class EventMessage(DataClassDictMixin):
     """Event for a change in trait value or device action."""
 
-    event_id: str = Field(alias="eventId")
     timestamp: datetime.datetime
-    resource_update_name: str | None
-    resource_update_events: dict[str, ImageEventBase] | None
-    resource_update_traits: dict[str, Any] | None
-    event_thread_state: str | None = Field(alias="eventThreadState")
-    relation_update: RelationUpdate | None = Field(alias="relationUpdate")
+    event_id: str = field(metadata=field_options(alias="eventId"))
+    resource_update_name: str | None = field(default=None)
+    resource_update_events: dict[str, ImageEventBase] | None = field(default=None)
+    resource_update_traits: dict[str, Any] | None = field(default=None)
+    event_thread_state: str | None = field(
+        metadata=field_options(alias="eventThreadState"), default=None
+    )
+    relation_update: RelationUpdate | None = field(
+        metadata=field_options(alias="relationUpdate"), default=None
+    )
 
-    def __init__(self, raw_data: Mapping[str, Any], auth: AbstractAuth) -> None:
+    _auth: AbstractAuth = field(init=False, metadata={"serialize": "omit"})
+
+    @classmethod
+    def create_event(
+        cls, raw_data: dict[str, Any], auth: AbstractAuth
+    ) -> "EventMessage":
         """Initialize an EventMessage."""
-        _LOGGER.debug("EventMessage raw_data=%s", raw_data)
-        super().__init__(**raw_data, auth=auth)
-        self._auth = auth
-
-    @root_validator(pre=True)
-    def _parse_resource_update(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Parse resource updates."""
-        if update := values.get(RESOURCE_UPDATE):
+        event_data = {**raw_data}
+        _LOGGER.debug("EventMessage raw_data=%s", event_data)
+        if update := event_data.get(RESOURCE_UPDATE):
             if name := update.get(NAME):
-                values["resource_update_name"] = name
+                event_data["resource_update_name"] = name
             if events := update.get(EVENTS):
-                values["resource_update_events"] = events
-                values["resource_update_events"][TIMESTAMP] = values.get(TIMESTAMP)
+                timestamp = event_data.get(TIMESTAMP)
+                for event_updates in events.values():
+                    event_updates[TIMESTAMP] = timestamp
+                event_data["resource_update_events"] = events
+                event_data["resource_update_events"][TIMESTAMP] = timestamp
             if traits := update.get(TRAITS):
-                values["resource_update_traits"] = traits
-                values["resource_update_traits"][NAME] = update.get(NAME)
-        return values
+                event_data["resource_update_traits"] = traits
+                event_data["resource_update_traits"][NAME] = update.get(NAME)
 
-    @validator("resource_update_events", pre=True)
-    def _parse_resource_update_events(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Parse resource updates for events."""
-        return _BuildEvents(values, _validate_datetime(values[TIMESTAMP]))
+        event = cls.from_dict(event_data)
+        event._auth = auth
+        return event
 
     @property
     def event_sessions(self) -> dict[str, dict[str, ImageEventBase]] | None:
@@ -385,7 +431,7 @@ class EventMessage(BaseModel):
     @property
     def raw_data(self) -> dict[str, Any]:
         """Return raw data for the event."""
-        return self.dict()
+        return self.to_dict(by_alias=True)
 
     def with_events(
         self,
@@ -393,7 +439,7 @@ class EventMessage(BaseModel):
         merge_data: dict[str, ImageEventBase] | None = None,
     ) -> EventMessage:
         """Create a new EventMessage minus some existing events by key."""
-        new_message = self.copy()
+        new_message = EventMessage.create_event(self.to_dict(by_alias=True), self._auth)
         if not merge_data:
             merge_data = {}
         new_events = {}
@@ -415,8 +461,13 @@ class EventMessage(BaseModel):
 
     def __repr__(self) -> str:
         """Debug information."""
-        return f"EventMessage{self.raw_data}"
+        return f"EventMessage{self.to_dict()}"
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = "allow"
+    class Config(BaseConfig):
+        serialization_strategy = {
+            dict[str, ImageEventBase]: UpdateEventsSerializationStrategy(),
+        }
+        code_generation_options = [
+            "TO_DICT_ADD_BY_ALIAS_FLAG",
+            "TO_DICT_ADD_OMIT_NONE_FLAG",
+        ]

--- a/google_nest_sdm/event.py
+++ b/google_nest_sdm/event.py
@@ -209,9 +209,6 @@ class ImageEventBase(DataClassDictMixin, ABC):
             )
         return event
 
-    def __repr__(self) -> str:
-        return "<ImageEventBase " + str(self.as_dict()) + ">"
-
     class Config(BaseConfig):
         serialization_strategy = {
             EventImageContentType: EventImageTypeSerializationStrategy(),
@@ -361,7 +358,6 @@ class UpdateEventsSerializationStrategy(SerializationStrategy, use_annotations=T
     def deserialize(self, value: dict[str, Any]) -> dict[str, ImageEventBase]:
         result = {}
         for event_type, event_data in value.items():
-            _LOGGER.debug("Deserializing event type %s", event_type)
             image_event = _BuildEvent(event_type, event_data)
             if not image_event:
                 continue
@@ -402,7 +398,6 @@ class EventMessage(DataClassDictMixin):
                 for event_updates in events.values():
                     event_updates[TIMESTAMP] = timestamp
                 event_data["resource_update_events"] = events
-                event_data["resource_update_events"][TIMESTAMP] = timestamp
             if traits := update.get(TRAITS):
                 event_data["resource_update_traits"] = traits
                 event_data["resource_update_traits"][NAME] = update.get(NAME)

--- a/google_nest_sdm/event_media.py
+++ b/google_nest_sdm/event_media.py
@@ -250,9 +250,7 @@ class ImageEventSerializationStrategy(SerializationStrategy):
                 data := event_data.get("event_data")
             ):
                 data["timestamp"] = timestamp
-            if isinstance(event_data, ImageEventBase):
-                events[event_type] = event_data
-            elif event := ImageEventBase.parse_event_dict(event_data):
+            if event := ImageEventBase.parse_event_dict(event_data):
                 events[event_type] = event
 
         # Link events to other events in the session

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -1,4 +1,5 @@
 """Subscriber for the Smart Device Management event based API."""
+
 from __future__ import annotations
 
 import asyncio
@@ -337,9 +338,9 @@ class GoogleNestSubscriber:
         self._loop = loop or asyncio.get_event_loop()
         self._device_manager_task: asyncio.Task[DeviceManager] | None = None
         self._subscriber_factory = subscriber_factory
-        self._subscriber_future: pubsub_v1.subscriber.futures.StreamingPullFuture | None = (  # noqa: E501
-            None
-        )
+        self._subscriber_future: (
+            pubsub_v1.subscriber.futures.StreamingPullFuture | None
+        ) = None  # noqa: E501
         self._callback: Callable[[EventMessage], Awaitable[None]] | None = None
         self._healthy = True
         self._watchdog_check_interval_seconds = watchdog_check_interval_seconds
@@ -535,7 +536,7 @@ class GoogleNestSubscriber:
     ) -> None:
         """Handle a received message."""
         payload = json.loads(bytes.decode(message.data))
-        event = EventMessage(payload, self._auth)
+        event = EventMessage.create_event(payload, self._auth)
         recv = time.time()
         latency_ms = int((recv - event.timestamp.timestamp()) * 1000)
         DIAGNOSTICS.elapsed("message_received", latency_ms)

--- a/google_nest_sdm/model.py
+++ b/google_nest_sdm/model.py
@@ -19,12 +19,6 @@ class TraitDataClass(DataClassDictMixin):
     This is meant to be subclasses by the model definitions.
     """
 
-    _EXCLUDE_FIELDS = set(
-        {
-            "_trait_event_ts",
-        }
-    )
-
     @classmethod
     def parse_trait_object(cls, raw_data: Mapping[str, Any]) -> Self:
         """Parse a new dataclass"""
@@ -51,8 +45,6 @@ class TraitDataClass(DataClassDictMixin):
         """Return raw data for the object."""
         result: dict[str, Any] = {}
         for k, v in self.to_dict(by_alias=True, omit_none=True).items():
-            if k in self._EXCLUDE_FIELDS:
-                continue
             if k.startswith(SDM_PREFIX):
                 if "traits" not in result:
                     result["traits"] = {}

--- a/google_nest_sdm/model.py
+++ b/google_nest_sdm/model.py
@@ -79,10 +79,11 @@ class TraitDataClass(DataClassDictMixin):
     @classmethod
     def parse_trait_object(cls, raw_data: Mapping[str, Any]) -> TraitDataClass:
         """Parse a new dataclass"""
-        if traits := raw_data.get(TRAITS):
-            raw_data.update(traits)
-            del raw_data["traits"]
-        return cls.from_dict(raw_data)
+        data = {
+            **raw_data,
+        }
+        data.update(raw_data.get(TRAITS, {}))
+        return cls.from_dict(data)
 
     @property
     def traits(self) -> dict[str, Any]:

--- a/google_nest_sdm/registry.py
+++ b/google_nest_sdm/registry.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, Any
 
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # pylint: disable=invalid-name
 
 
-class Registry(dict):
+class Registry(dict[str, Any]):
     """Registry of items."""
 
     def register(self, name: str | None = None) -> Callable[[CALLABLE_T], CALLABLE_T]:

--- a/google_nest_sdm/structure.py
+++ b/google_nest_sdm/structure.py
@@ -2,45 +2,46 @@
 
 from __future__ import annotations
 
-from typing import Any, Final, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+from mashumaro import DataClassDictMixin, field_options
 
-try:
-    from pydantic.v1 import BaseModel, Field
-except ImportError:
-    from pydantic import BaseModel, Field  # type: ignore
-
-from .model import TraitModel
+from .model import TraitDataClass
 
 
-class StructureTrait(BaseModel):
+@dataclass
+class InfoTrait(DataClassDictMixin):
     """This trait belongs to any structure for structure-related information."""
 
-    custom_name: str = Field(alias="customName")
+    custom_name: str = field(metadata=field_options(alias="customName"), default=None)
     """Name of the structure."""
 
 
-class InfoTrait(StructureTrait):
-    """This trait belongs to any structure for structure-related information."""
-
-    NAME: Final = "sdm.structures.traits.Info"
-
-
-class RoomInfoTrait(StructureTrait):
+@dataclass
+class RoomInfoTrait(DataClassDictMixin):
     """This trait belongs to any structure for room-related information."""
 
-    NAME: Final = "sdm.structures.traits.RoomInfo"
+    custom_name: str = field(metadata=field_options(alias="customName"))
+    """Name of the structure."""
 
 
-class Structure(TraitModel):
+@dataclass
+class Structure(TraitDataClass):
     """Class that represents a structure object in the Google Nest SDM API."""
 
     name: str
     """Resource name of the structure e.g. 'enterprises/XYZ/structures/123'."""
 
-    info: InfoTrait | None = Field(alias="sdm.structures.traits.Info")
-    room_info: RoomInfoTrait | None = Field(alias="sdm.structures.traits.RoomInfo")
+    info: InfoTrait | None = field(
+        metadata=field_options(alias="sdm.structures.traits.Info"),
+        default=None
+    )
+    room_info: RoomInfoTrait | None = field(
+        metadata=field_options(alias="sdm.structures.traits.RoomInfo"),
+        default=None
+    )
 
     @staticmethod
     def MakeStructure(raw_data: Mapping[str, Any]) -> Structure:
         """Create a structure with the appropriate traits."""
-        return Structure.parse_obj(raw_data)
+        return Structure.parse_trait_object(raw_data)

--- a/google_nest_sdm/structure.py
+++ b/google_nest_sdm/structure.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping, cast
-from mashumaro import DataClassDictMixin, field_options
+from typing import Any, Mapping
+from mashumaro import field_options
 
 from .model import TraitDataClass
 
@@ -13,7 +13,9 @@ from .model import TraitDataClass
 class InfoTrait:
     """This trait belongs to any structure for structure-related information."""
 
-    custom_name: str | None = field(metadata=field_options(alias="customName"), default=None)
+    custom_name: str | None = field(
+        metadata=field_options(alias="customName"), default=None
+    )
     """Name of the structure."""
 
 
@@ -33,15 +35,13 @@ class Structure(TraitDataClass):
     """Resource name of the structure e.g. 'enterprises/XYZ/structures/123'."""
 
     info: InfoTrait | None = field(
-        metadata=field_options(alias="sdm.structures.traits.Info"),
-        default=None
+        metadata=field_options(alias="sdm.structures.traits.Info"), default=None
     )
     room_info: RoomInfoTrait | None = field(
-        metadata=field_options(alias="sdm.structures.traits.RoomInfo"),
-        default=None
+        metadata=field_options(alias="sdm.structures.traits.RoomInfo"), default=None
     )
 
     @classmethod
     def MakeStructure(cls, raw_data: Mapping[str, Any]) -> Structure:
         """Create a structure with the appropriate traits."""
-        return cast(Structure, cls.parse_trait_object(raw_data))
+        return cls.parse_trait_object(raw_data)

--- a/google_nest_sdm/structure.py
+++ b/google_nest_sdm/structure.py
@@ -3,22 +3,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 from mashumaro import DataClassDictMixin, field_options
 
 from .model import TraitDataClass
 
 
 @dataclass
-class InfoTrait(DataClassDictMixin):
+class InfoTrait:
     """This trait belongs to any structure for structure-related information."""
 
-    custom_name: str = field(metadata=field_options(alias="customName"), default=None)
+    custom_name: str | None = field(metadata=field_options(alias="customName"), default=None)
     """Name of the structure."""
 
 
 @dataclass
-class RoomInfoTrait(DataClassDictMixin):
+class RoomInfoTrait:
     """This trait belongs to any structure for room-related information."""
 
     custom_name: str = field(metadata=field_options(alias="customName"))
@@ -41,7 +41,7 @@ class Structure(TraitDataClass):
         default=None
     )
 
-    @staticmethod
-    def MakeStructure(raw_data: Mapping[str, Any]) -> Structure:
+    @classmethod
+    def MakeStructure(cls, raw_data: Mapping[str, Any]) -> Structure:
         """Create a structure with the appropriate traits."""
-        return Structure.parse_trait_object(raw_data)
+        return cast(Structure, cls.parse_trait_object(raw_data))

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,5 @@
 [mypy]
-plugins = pydantic.mypy
-
 follow_imports = silent
-
 ignore_missing_imports = True
 exclude = (venv|build)
 check_untyped_defs = True
@@ -19,9 +16,3 @@ warn_no_return = True
 show_error_codes = True
 # For temporarily dealing with mypy updates (#151 and #152)
 warn_unused_ignores = False
-
-[pydantic-mypy]
-init_forbid_extra = True
-init_typed = True
-warn_required_dynamic_aliases = True
-warn_untyped_fields = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ grpcio-status==1.62.1
 mypy==1.9.0
 pre-commit==3.7.0
 protobuf==4.25.3
-pydantic==2.6.4
 pytest==8.1.1
 pytest-aiohttp==1.0.5
 pytest-asyncio==0.23.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ typing-inspect==0.9.0
 urllib3==2.2.1
 ruff==0.3.4
 pdoc==14.4.0
+mashumaro==3.12

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "requests-oauthlib>=1.3.0",
         "PyYAML>=6.0",
         "pydantic>=1.10.4",
+        "mashumaro>=3.12",
     ],
     python_requires=">=3.11",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "google-cloud-pubsub>=2.1.0",
         "requests-oauthlib>=1.3.0",
         "PyYAML>=6.0",
-        "pydantic>=1.10.4",
         "mashumaro>=3.12",
     ],
     python_requires=">=3.11",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ def event_message(
     app: aiohttp.web.Application, auth_client: Callable[[], Awaitable[AbstractAuth]]
 ) -> Callable[[Dict[str, Any]], Awaitable[EventMessage]]:
     async def _make_event(raw_data: Dict[str, Any]) -> EventMessage:
-        return EventMessage(raw_data, await auth_client())
+        return EventMessage.create_event(raw_data, await auth_client())
 
     return _make_event
 
@@ -148,7 +148,7 @@ def event_message(
 @pytest.fixture
 def fake_event_message() -> Callable[[Dict[str, Any]], EventMessage]:
     def _make_event(raw_data: Dict[str, Any]) -> EventMessage:
-        return EventMessage(raw_data, cast(AbstractAuth, None))
+        return EventMessage.create_event(raw_data, cast(AbstractAuth, None))
 
     return _make_event
 

--- a/tests/test_camera_traits.py
+++ b/tests/test_camera_traits.py
@@ -312,6 +312,7 @@ async def test_camera_live_stream_rtsp(
                         },
                         "videoCodecs": ["H264"],
                         "audioCodecs": ["AAC"],
+                        "supportedProtocols": ["RTSP"],
                     }
                 },
                 "type": "sdm.devices.types.device-type1",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Callable, Dict
 
+import pytest
+
 from google_nest_sdm.device import Device
 
 
@@ -35,6 +37,15 @@ def test_empty_traits(fake_device: Callable[[Dict[str, Any]], Device]) -> None:
     )
     assert "my/device/name" == device.name
     assert "sdm.devices.traits.Info" not in device.traits
+
+
+def test_no_name(fake_device: Callable[[Dict[str, Any]], Device]) -> None:
+    with pytest.raises(ValueError, match="'name' is required"):
+        fake_device(
+            {
+                "traits": {},
+            }
+        )
 
 
 def test_no_parent_relations(fake_device: Callable[[Dict[str, Any]], Device]) -> None:

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -406,7 +406,7 @@ async def test_update_trait_with_field_alias(
     fake_device: Callable[[Dict[str, Any]], Device],
     fake_event_message: Callable[[Dict[str, Any]], EventMessage],
 ) -> None:
-    """Test updating a trait that has fields with pydantic field aliases."""
+    """Test updating a trait that has fields with field aliases."""
     device = fake_device(
         {
             "name": "my/device/name1",
@@ -531,7 +531,6 @@ async def test_update_trait_ordering(
     assert get_connectivity().status == "ONLINE"
 
 
-
 async def test_update_trait_with_new_field(
     fake_device: Callable[[Dict[str, Any]], Device],
     fake_event_message: Callable[[Dict[str, Any]], EventMessage],
@@ -590,7 +589,6 @@ async def test_update_trait_with_new_field(
     assert not device.temperature
 
     unregister()
-
 
 
 @pytest.mark.parametrize(

--- a/tests/test_device_traits.py
+++ b/tests/test_device_traits.py
@@ -3,11 +3,6 @@
 import datetime
 from typing import Any, Callable, Dict
 
-try:
-    from pydantic.v1 import ValidationError
-except ImportError:
-    from pydantic import ValidationError  # type: ignore
-
 import pytest
 
 from google_nest_sdm.device import Device
@@ -171,7 +166,7 @@ def test_info_traits_type_error(
     assert "my/device/name" == device.name
     assert "sdm.devices.traits.Info" in device.traits
     trait = device.traits["sdm.devices.traits.Info"]
-    assert trait.custom_name == "12345"
+    assert trait.custom_name == 12345
 
 
 def test_info_traits_missing_optional_field(
@@ -194,7 +189,7 @@ def test_info_traits_missing_optional_field(
 def test_connectivity_traits_missing_required_field(
     fake_device: Callable[[Dict[str, Any]], Device]
 ) -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         fake_device(
             {
                 "name": "my/device/name",

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -259,7 +259,7 @@ def test_event_serialization(
     dump = json.dumps(data)
     data = json.loads(dump)
 
-    e = ImageEventBase.from_dict(data)
+    e = ImageEventBase.parse_event_dict(data)
     assert e
     assert isinstance(e, CameraClipPreviewEvent)
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -464,3 +464,30 @@ def test_event_message_repr(
         }
     )
     assert "EventMessage{" in repr(event)
+    assert event.resource_update_events
+    assert "sdm.devices.events.CameraMotion.Motion" in event.resource_update_events
+    motion = event.resource_update_events["sdm.devices.events.CameraMotion.Motion"]
+    assert motion
+    assert "CameraMotionEvent(" in repr(motion)
+
+
+
+def test_missing_preview_url(
+    fake_event_message: Callable[[Dict[str, Any]], EventMessage]
+) -> None:
+    with pytest.raises(ValueError, match="EventMessage has invalid value"):
+        fake_event_message(
+            {
+                "eventId": "201fcd21-967a-4f82-8082-5073bd09d31f",
+                "timestamp": "2019-01-01T00:00:01Z",
+                "resourceUpdate": {
+                    "name": "enterprises/project-id/devices/device-id",
+                    "events": {
+                        "sdm.devices.events.CameraClipPreview.ClipPreview": {
+                            "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                        }
+                    },
+                },
+                "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+            }
+        )

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -413,3 +413,54 @@ def test_event_zone(
     assert "FWWVQVUdGNUlTU2V4MGV2aTNXV..." == e.event_id
     assert "CjY5Y3VKaTZwR3o4Y19YbTVfMF..." == e.event_session_id
     assert e.zones == ["Zone 1"]
+
+
+def test_unknown_event_type(
+    fake_event_message: Callable[[Dict[str, Any]], EventMessage]
+) -> None:
+    """Test at event published with a type that is not recognized."""
+    event = fake_event_message(
+        {
+            "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+            "timestamp": "2019-01-01T00:00:01Z",
+            "resourceUpdate": {
+                "name": "enterprises/project-id/devices/device-id",
+                "events": {
+                    "sdm.devices.events.Ignored.EventType": {
+                        "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                        "eventId": "FWWVQVUdGNUlTU2V4MGV2aTNXV...",
+                    }
+                },
+            },
+            "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+        }
+    )
+    assert event.event_id == "0120ecc7-3b57-4eb4-9941-91609f189fb4"
+    assert event.timestamp == datetime.datetime(
+        2019, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc
+    )
+    assert event.resource_update_name == "enterprises/project-id/devices/device-id"
+    assert event.resource_update_events == {}
+
+
+def test_event_message_repr(
+    fake_event_message: Callable[[Dict[str, Any]], EventMessage]
+) -> None:
+    """Test at event published with a type that is not recognized."""
+    event = fake_event_message(
+        {
+            "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+            "timestamp": "2019-01-01T00:00:01Z",
+            "resourceUpdate": {
+                "name": "enterprises/project-id/devices/device-id",
+                "events": {
+                    "sdm.devices.events.CameraMotion.Motion": {
+                        "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                        "eventId": "FWWVQVUdGNUlTU2V4MGV2aTNXV...",
+                    }
+                },
+            },
+            "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+        }
+    )
+    assert "EventMessage{" in repr(event)

--- a/tests/test_event_media.py
+++ b/tests/test_event_media.py
@@ -1662,6 +1662,9 @@ async def test_invalid_events_persisted(device: Device) -> None:
                     },
                     "sdm.devices.events.DoorbellChime.Chime": {
                         "event_type": "sdm.devices.events.DoorbellChime.Chime",
+                    },
+                    "sdm.devices.events.DoorbellChime.Chime": {
+                        "event_type": "sdm.devices.events.DoorbellChime.Chime",
                         "event_data": {
                             "eventSessionId": "AVPHwEtyzgSxu6EuaIOfvz...",
                             "eventId": "CiUA2vuxr_zoChpekrBmo...",

--- a/tests/test_event_media.py
+++ b/tests/test_event_media.py
@@ -1,4 +1,5 @@
 """Tests for event_media.py"""
+
 import datetime
 from typing import Any, Awaitable, Callable, Dict
 from unittest.mock import patch
@@ -1641,3 +1642,64 @@ async def test_unsupported_event_trait(
     event_media_manager = device.event_media_manager
     assert len(list(await event_media_manager.async_image_sessions())) == 0
     assert len(list(await event_media_manager.async_clip_preview_sessions())) == 0
+
+
+@pytest.mark.parametrize("device_traits", [IMAGE_DOORBELL_TRAITS])
+async def test_invalid_events_persisted(device: Device) -> None:
+    data = {
+        device.name: [
+            {
+                "event_session_id": "AVPHwEtyzgSxu6EuaIOfvz...",
+                "events": {
+                    "sdm.devices.events.Ignored.Ignored": {
+                        "event_type": "sdm.devices.events.Ignored.Ignored",
+                        "event_data": {
+                            "eventSessionId": "AVPHwEtyzgSxu6EuaIOfvz...",
+                            "eventId": "CiUA2vuxrwjZjb0daCbmE...",
+                        },
+                        "timestamp": "2021-12-23T06:35:35.791000+00:00",
+                        "event_image_type": "image/jpeg",
+                    },
+                    "sdm.devices.events.DoorbellChime.Chime": {
+                        "event_type": "sdm.devices.events.DoorbellChime.Chime",
+                        "event_data": {
+                            "eventSessionId": "AVPHwEtyzgSxu6EuaIOfvz...",
+                            "eventId": "CiUA2vuxr_zoChpekrBmo...",
+                        },
+                        "timestamp": "2021-12-23T06:35:36.101000+00:00",
+                        "event_image_type": "image/jpeg",
+                    },
+                },
+                "event_media_keys": {
+                    "CiUA2vuxrwjZjb0daCbmE...": (
+                        "AVPHwEtyzgSxu6EuaIOfvzmr7-CiUA2vuxrwjZjb0daCbmE-motion.jpg"
+                    ),
+                    "CiUA2vuxr_zoChpekrBmo...": (
+                        "AVPHwEtyzgSxu6EuaIOfvzmr7-CiUA2vuxr_zoChpekrBmo-doorbell.jpg"
+                    ),
+                },
+            },
+        ],
+    }
+    event_media_manager = device.event_media_manager
+    store = event_media_manager.cache_policy.store
+    await store.async_save(data)
+    await store.async_save_media(
+        "AVPHwEtyzgSxu6EuaIOfvzmr7-CiUA2vuxrwjZjb0daCbmE-motion.jpg",
+        b"image-bytes-1",
+    )
+    await store.async_save_media(
+        "AVPHwEtyzgSxu6EuaIOfvzmr7-CiUA2vuxr_zoChpekrBmo-doorbell.jpg",
+        b"image-bytes-2",
+    )
+
+    event_media_manager = device.event_media_manager
+
+    events = list(await event_media_manager.async_image_sessions())
+    assert len(events) == 1
+    event = events[0]
+    event_token = EventToken.decode(event.event_token)
+    assert event_token.event_session_id == "AVPHwEtyzgSxu6EuaIOfvz..."
+    assert event_token.event_id == "CiUA2vuxr_zoChpekrBmo..."
+    assert event.event_type == "sdm.devices.events.DoorbellChime.Chime"
+    assert event.timestamp.isoformat(timespec="seconds") == "2021-12-23T06:35:36+00:00"

--- a/tests/test_event_media.py
+++ b/tests/test_event_media.py
@@ -1660,8 +1660,8 @@ async def test_invalid_events_persisted(device: Device) -> None:
                         "timestamp": "2021-12-23T06:35:35.791000+00:00",
                         "event_image_type": "image/jpeg",
                     },
-                    "sdm.devices.events.DoorbellChime.Chime": {
-                        "event_type": "sdm.devices.events.DoorbellChime.Chime",
+                    "sdm.devices.events.CameraMotion.Motion": {
+                        "event_type": "sdm.devices.events.CameraMotion.Motion",
                     },
                     "sdm.devices.events.DoorbellChime.Chime": {
                         "event_type": "sdm.devices.events.DoorbellChime.Chime",

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -238,7 +238,7 @@ async def test_subscribe_update_trait(
             "data": {
                 "name": "**REDACTED**",
                 "parentRelations": [],
-                "traits": {"sdm.devices.traits.Connectivity": {"status": "ONLINE"}},
+                "traits": {"sdm.devices.traits.Connectivity": {"status": "OFFLINE"}},
                 "type": "sdm.devices.types.device-type1",
             },
         },


### PR DESCRIPTION
Replace use of pydantic with mashumaro. The motivation is to move to a simpler more pythonic library that does not have harmful deprecation practices.