### PR TITLE
Fix displayName redaction regression and add test coverage

### DIFF
--- a/google_nest_sdm/diagnostics.py
+++ b/google_nest_sdm/diagnostics.py
@@ -12,6 +12,7 @@ __all__ = [
     "get_diagnostics",
 ]
 
+
 class Diagnostics:
     """Information for the library."""
 
@@ -88,7 +89,7 @@ def get_diagnostics() -> dict[str, Any]:
 REDACT_KEYS = {
     "name",
     "custom_name",
-    "display_name",
+    "displayName",
     "parent",
     "assignee",
     "subject",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = google_nest_sdm
-version = 4.0.3
+version = 4.0.4
 description = Library for the Google Nest SDM API
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = google_nest_sdm
-version = 4.0.4
+version = 4.0.3
 description = Library for the Google Nest SDM API
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -6,6 +6,8 @@ import pytest
 
 from google_nest_sdm.device import Device
 
+from .conftest import assert_diagnostics
+
 
 def test_device_id(fake_device: Callable[[Dict[str, Any]], Device]) -> None:
     device = fake_device(
@@ -99,6 +101,21 @@ def test_parent_relation(fake_device: Callable[[Dict[str, Any]], Device]) -> Non
     )
     assert "my/device/name" == device.name
     assert {"my/structure/or/room": "Some Name"} == device.parent_relations
+
+    assert_diagnostics(
+        device.get_diagnostics(),
+        {
+            "data": {
+                "name": "**REDACTED**",
+                "parentRelations": [
+                    {
+                        "parent": "**REDACTED**",
+                        "displayName": "**REDACTED**",
+                    }
+                ],
+            },
+        },
+    )
 
 
 def test_multiple_parent_relations(


### PR DESCRIPTION
Fix displayName redaction regression and add test coverage. This was broken by changing some of the names to match the new pydantic style, which only applied to traits (using by_alias=True)