### PR TITLE
Change behavior of device callback to pass through raw messages without waiting for media

### DIFF
--- a/google_nest_sdm/device_manager.py
+++ b/google_nest_sdm/device_manager.py
@@ -52,7 +52,11 @@ class DeviceManager:
     def set_update_callback(
         self, target: Callable[[EventMessage], Awaitable[None]]
     ) -> None:
-        """Register a callback invoked when new messages are received."""
+        """Register a callback invoked when new messages are received.
+        
+        If the event is associated with media, then the callback will only
+        be invoked once the media has been fetched.
+        """
         self._callback = target
         for device in self._devices.values():
             device.event_media_manager.set_update_callback(target)

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -374,7 +374,11 @@ class GoogleNestSubscriber:
     def set_update_callback(
         self, target: Callable[[EventMessage], Awaitable[None]]
     ) -> None:
-        """Register a callback invoked when new messages are received."""
+        """Register a callback invoked when new messages are received.
+        
+        If the event is associated with media, then the callback will only
+        be invoked once the media has been fetched.
+        """
         self._callback = target
         if self._device_manager_task and self._device_manager_task.done():
             self._device_manager_task.result().set_update_callback(target)
@@ -577,7 +581,7 @@ class GoogleNestSubscriber:
         # Only accept device events once the Device Manager has been loaded.
         # We are ok with missing messages on startup since the device manager
         # will do a live read. This checks for an exception to avoid throwing
-        # inside the pubsub callback and further weding the pubsub client library.
+        # inside the pubsub callback and further wedging the pubsub client library.
         if (
             self._device_manager_task
             and self._device_manager_task.done()

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -662,7 +662,7 @@ async def test_publish_without_media(
     fake_device: Callable[[Dict[str, Any]], Device],
     fake_event_message: Callable[[Dict[str, Any]], EventMessage],
 ) -> None:
-    """Test event callback is registered before the device is added."""
+    """Test publishing an event without any associated event media."""
 
     callback = EventCallback()
     mgr = DeviceManager()

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -579,7 +579,7 @@ async def test_subscribe_thread_update(
     assert "sdm.devices.events.CameraMotion.Motion" in events
     assert "sdm.devices.events.CameraClipPreview.ClipPreview" in events
 
-    # Device-level callback recieves both raw messages
+    # Device-level callback invoked with both raw messages
     assert len(device_callback.messages) == 2
     message: EventMessage = device_callback.messages[0]
     assert message.event_id == "6f29332e-5537-47f6-a3f9-840c307340f5"

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -569,7 +569,7 @@ async def test_subscribe_thread_update(
     await subscriber_factory.async_push_event(event)
 
     assert len(subscriber_callback.messages) == 1
-    message: EventMessage = subscriber_callback.messages[0]
+    message = subscriber_callback.messages[0]
     assert message.event_id == "6f29332e-5537-47f6-a3f9-840c307340f5"
     assert message.event_sessions
     assert len(message.event_sessions) == 1
@@ -581,9 +581,9 @@ async def test_subscribe_thread_update(
 
     # Device-level callback invoked with both raw messages
     assert len(device_callback.messages) == 2
-    message: EventMessage = device_callback.messages[0]
+    message = device_callback.messages[0]
     assert message.event_id == "6f29332e-5537-47f6-a3f9-840c307340f5"
-    message: EventMessage = device_callback.messages[1]
+    message = device_callback.messages[1]
     assert message.event_id == "7f29332e-5537-47f6-a3f9-840c307340f5"
 
     subscriber.stop_async()


### PR DESCRIPTION
Device level callbacks added by `add_event_callback` and `add_update_listener` will now be invoked without waiting for associated event media to be fetched. The behavior is not changed for the subscriber, device, or event media manager callbacks which wait for media to be fetched.