### PR TITLE
Workaround for Nest SDP answer bugs to pass firefox validation

### DIFF
--- a/google_nest_sdm/camera_traits.py
+++ b/google_nest_sdm/camera_traits.py
@@ -280,9 +280,7 @@ class CameraLiveStreamTrait(DataClassDictMixin, CommandDataClass):
         obj = WebRtcStream.from_dict(results)
         obj._cmd = self.cmd
         _LOGGER.debug("Received answer_sdp: %s", obj.answer_sdp)
-        obj.answer_sdp = fix_mozilla_sdp_answer(
-                offer_sdp, obj.answer_sdp
-            )
+        obj.answer_sdp = fix_mozilla_sdp_answer(offer_sdp, obj.answer_sdp)
         _LOGGER.debug("Return answer_sdp: %s", obj.answer_sdp)
         return obj
 

--- a/google_nest_sdm/camera_traits.py
+++ b/google_nest_sdm/camera_traits.py
@@ -62,7 +62,9 @@ ANSWER_SDP = "answerSdp"
 MEDIA_SESSION_ID = "mediaSessionId"
 
 EVENT_IMAGE_CLIP_PREVIEW = "clip_preview"
-
+WEBRTC_STREAM_DIRECTION_SENDONLY = "sendonly"
+WEBRTC_STREAM_DIRECTION_SENDRECV = "sendrecv"
+WEBRTC_STREAM_DIRECTION_RECVONLY = "recvonly"
 
 @dataclass
 class Resolution:
@@ -266,6 +268,31 @@ class CameraLiveStreamTrait(DataClassDictMixin, CommandDataClass):
         obj._cmd = self.cmd
         return obj
 
+    def get_direction(self, text, section):
+        for part in text.split("\nm="):
+            if part.startswith(section):
+                if "\na="+WEBRTC_STREAM_DIRECTION_SENDRECV in part:
+                    return WEBRTC_STREAM_DIRECTION_SENDRECV
+                elif "\na="+WEBRTC_STREAM_DIRECTION_RECVONLY in part:
+                    return WEBRTC_STREAM_DIRECTION_RECVONLY
+        return None
+
+    def set_direction(self, text, section, from_direction, to_direction):
+        for part in text.split("\nm="):
+            if part.startswith(section) and "\na="+from_direction in part:
+                return text.replace("m="+part, "m="+part.replace("\na="+from_direction, "\na="+to_direction))
+        return text
+
+    def set_candidate_foundation(self, text):
+        result = text
+        index = 1
+        for line in text.split("\r\n"):
+            if line.startswith("a=candidate: "):
+                result = result.replace(line, line.replace(
+                    "a=candidate: ", "a=candidate:"+str(index)+" "))
+                index += 1
+        return result
+
     async def generate_web_rtc_stream(self, offer_sdp: str) -> WebRtcStream:
         """Request a token to access a Web RTC live stream URL."""
         if StreamingProtocol.WEB_RTC not in self.supported_protocols:
@@ -278,6 +305,16 @@ class CameraLiveStreamTrait(DataClassDictMixin, CommandDataClass):
         results = response_data[RESULTS]
         obj = WebRtcStream.from_dict(results)
         obj._cmd = self.cmd
+        _LOGGER.debug("Received answer_sdp: %s", obj.answer_sdp)
+        if "mozilla" in offer_sdp:
+            if self.get_direction(offer_sdp, "video") == WEBRTC_STREAM_DIRECTION_RECVONLY:
+                obj.answer_sdp = self.set_direction(
+                    obj.answer_sdp, "video", WEBRTC_STREAM_DIRECTION_SENDRECV, WEBRTC_STREAM_DIRECTION_SENDONLY)
+            if self.get_direction(offer_sdp, "audio") == WEBRTC_STREAM_DIRECTION_RECVONLY:
+                obj.answer_sdp = self.set_direction(
+                    obj.answer_sdp, "audio", WEBRTC_STREAM_DIRECTION_SENDRECV, WEBRTC_STREAM_DIRECTION_SENDONLY)
+            obj.answer_sdp = self.set_candidate_foundation(obj.answer_sdp)
+            _LOGGER.debug("Return obj.answer_sdp: %s", obj.answer_sdp)
         return obj
 
     class Config(BaseConfig):

--- a/google_nest_sdm/camera_traits.py
+++ b/google_nest_sdm/camera_traits.py
@@ -24,7 +24,7 @@ from .event import (
     EventType,
 )
 from .traits import CommandDataClass, TraitType
-from .webrtc_util import WebRTCUtility
+from .webrtc_util import fix_mozilla_sdp_answer
 
 __all__ = [
     "CameraImageTrait",
@@ -280,11 +280,10 @@ class CameraLiveStreamTrait(DataClassDictMixin, CommandDataClass):
         obj = WebRtcStream.from_dict(results)
         obj._cmd = self.cmd
         _LOGGER.debug("Received answer_sdp: %s", obj.answer_sdp)
-        if "mozilla" in offer_sdp:
-            obj.answer_sdp = WebRTCUtility().fix_mozilla_sdp_answer(
+        obj.answer_sdp = fix_mozilla_sdp_answer(
                 offer_sdp, obj.answer_sdp
             )
-            _LOGGER.debug("Return obj.answer_sdp: %s", obj.answer_sdp)
+        _LOGGER.debug("Return answer_sdp: %s", obj.answer_sdp)
         return obj
 
     class Config(BaseConfig):

--- a/google_nest_sdm/webrtc_util.py
+++ b/google_nest_sdm/webrtc_util.py
@@ -1,0 +1,114 @@
+# SDP Direction Constants
+DIRECTION_SENDRECV = 'sendrecv'
+DIRECTION_SENDONLY = 'sendonly'
+DIRECTION_RECVONLY = 'recvonly'
+DIRECTION_INACTIVE = 'inactive'
+
+AVAILABLE_DIRECTIONS = [DIRECTION_SENDRECV,
+                        DIRECTION_SENDONLY,
+                        DIRECTION_RECVONLY,
+                        DIRECTION_INACTIVE]
+
+
+class WebRTCUtility:
+    """
+    This class provides methods for managing WebRTC SDP.
+    """
+
+    def get_media_direction(self, sdp, kind):
+        """
+        Retrieves the direction of media tracks from the SDP based on the kind (audio/video).
+
+        Args:
+            sdp (str): The SDP content
+            kind (str): The kind of media track to check ('audio' or 'video').
+
+        Returns:
+            str: The direction of the media track. One of 'sendrecv', 'sendonly', 'recvonly', or 'inactive'.
+        """
+        # Split the SDP into lines
+        lines = sdp.splitlines()
+
+        # Variable to track if we are in the desired media section
+        in_media_section = False
+
+        # Search for the media type and direction
+        for line in lines:
+            # Check if the line is a media description line (m=)
+            if line.startswith('m='):
+                in_media_section = (kind in line)
+
+            # If we're in the desired media section, check for direction
+            if in_media_section:
+                for direction in AVAILABLE_DIRECTIONS:
+                    if line.startswith(f'a={direction}'):
+                        return direction
+        return None
+
+    def update_direction_in_answer(self, answer_sdp, kind, old_direction, new_direction):
+        """
+        Updates the direction of a specific media track in the SDP answer if it matches a certain direction.
+
+        Args:
+            answer_sdp (str): The SDP answer in string format.
+            kind (str): The kind of media track to update ('audio' or 'video').
+            old_direction (str): The old direction to find ('sendrecv', 'sendonly', 'recvonly', 'inactive').
+            new_direction (str): The new direction to set ('sendrecv', 'sendonly', 'recvonly', 'inactive').
+
+        Returns:
+            str: The updated SDP with the new direction.
+        """
+
+        # Update the SDP
+        sdp_lines = answer_sdp.split('\r\n')
+        updated_sdp_lines = []
+        in_media_section = False
+
+        for line in sdp_lines:
+            if line.startswith('m='):
+                in_media_section = (kind in line)
+            if in_media_section and line.startswith('a='):
+                # Update the direction line if it matches the kind
+                if line.startswith(f'a={old_direction}'):
+                    updated_sdp_lines.append(f'a={new_direction}')
+                    continue
+            updated_sdp_lines.append(line)
+
+        updated_sdp = '\r\n'.join(updated_sdp_lines)
+        return updated_sdp
+
+    def add_foundation_to_candidates(self, sdp):
+        """
+        Adds a foundation value to all ICE candidates in the SDP if it does not already exist.
+
+        Args:
+            sdp (str): The SDP in string format.
+
+        Returns:
+            str: The updated SDP with the foundation value added to ICE candidates.
+        """
+        # Add the foundation value to each ICE candidate line
+        updated_sdp = sdp
+        index = 1
+        for line in sdp.split("\r\n"):
+            if line.startswith("a=candidate: "):
+                updated_sdp = updated_sdp.replace(line, line.replace(
+                    "a=candidate: ", "a=candidate:"+str(index)+" "))
+                index += 1
+        return updated_sdp
+
+    def fix_mozilla_sdp_answer(self, offer_sdp, answer_sdp):
+        """Fix the answer SDP which is rejected by Firefox.
+
+        1. If offer SDP is recvonly, the direction of answer SDP must not be sendrecv.
+        2. If the ICE candidates in answer SDP must contain "foundation" field.
+        """
+        if self.get_media_direction(sdp=offer_sdp, kind="video") == DIRECTION_RECVONLY:
+            answer_sdp = self.update_direction_in_answer(
+                answer_sdp=answer_sdp, kind="video", old_direction=DIRECTION_SENDRECV, new_direction=DIRECTION_SENDONLY)
+        if self.get_media_direction(sdp=offer_sdp, kind="audio") == DIRECTION_RECVONLY:
+            answer_sdp = self.update_direction_in_answer(
+                answer_sdp=answer_sdp, kind="audio", old_direction=DIRECTION_SENDRECV, new_direction=DIRECTION_SENDONLY)
+
+        answer_sdp = self.add_foundation_to_candidates(answer_sdp)
+        return answer_sdp

--- a/google_nest_sdm/webrtc_util.py
+++ b/google_nest_sdm/webrtc_util.py
@@ -30,12 +30,12 @@ def _get_media_direction(sdp: str, kind: SDPMediaKind) -> SDPDirection | None:
 
     for line in sdp.splitlines():
         # Check if the line is a media description line
-        if line.startswith('m='):
-            in_media_section = line.startswith(f'm={kind}')
+        if line.startswith("m="):
+            in_media_section = line.startswith(f"m={kind}")
         # If we're in the desired media section, check for direction
-        if in_media_section:
+        if in_media_section and line.startswith("a="):
             for direction in SDPDirection:
-                if line.startswith(f'a={direction}'):
+                if line.startswith(f"a={direction}"):
                     return direction
     return None
 
@@ -59,7 +59,7 @@ def _update_direction_in_answer(answer_sdp: str, kind: SDPMediaKind, old_directi
     in_media_section = False
     for line in answer_sdp.split("\r\n"):
         if line.startswith("m="):
-            in_media_section = (kind in line)
+            in_media_section = line.startswith(f"m={kind}")
         if in_media_section and line.startswith("a="):
             # Update the direction line if it matches the kind
             if line.startswith(f"a={old_direction}"):

--- a/google_nest_sdm/webrtc_util.py
+++ b/google_nest_sdm/webrtc_util.py
@@ -1,5 +1,7 @@
 """Library with functions for manipulating WebRTC requests/responses."""
+
 from enum import StrEnum
+
 
 # SDP direction constants
 class SDPDirection(StrEnum):
@@ -8,11 +10,13 @@ class SDPDirection(StrEnum):
     RECVONLY = "recvonly"
     INACTIVE = "inactive"
 
+
 # SDP media kind constants
 class SDPMediaKind(StrEnum):
     AUDIO = "audio"
     VIDEO = "video"
     APPLICATION = "application"
+
 
 def _get_media_direction(sdp: str, kind: SDPMediaKind) -> SDPDirection | None:
     """
@@ -40,7 +44,12 @@ def _get_media_direction(sdp: str, kind: SDPMediaKind) -> SDPDirection | None:
     return None
 
 
-def _update_direction_in_answer(answer_sdp: str, kind: SDPMediaKind, old_direction: SDPDirection, new_direction: SDPDirection) -> str:
+def _update_direction_in_answer(
+    answer_sdp: str,
+    kind: SDPMediaKind,
+    old_direction: SDPDirection,
+    new_direction: SDPDirection,
+) -> str:
     """
     Updates the direction of a specific media track in the SDP answer if it matches a certain direction.
 
@@ -84,7 +93,9 @@ def _add_foundation_to_candidates(sdp: str) -> str:
     index = 1
     for line in sdp.split("\r\n"):
         if line.startswith("a=candidate: "):
-            updated_sdp_lines.append(line.replace("a=candidate: ", f"a=candidate:{index} "))
+            updated_sdp_lines.append(
+                line.replace("a=candidate: ", f"a=candidate:{index} ")
+            )
             index += 1
             continue
         updated_sdp_lines.append(line)
@@ -98,11 +109,25 @@ def fix_mozilla_sdp_answer(offer_sdp: str, answer_sdp: str) -> str:
     2. If the ICE candidates in answer SDP must contain "foundation" field.
     """
     if "mozilla" in offer_sdp:
-        if _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.VIDEO) == SDPDirection.RECVONLY:
+        if (
+            _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.VIDEO)
+            == SDPDirection.RECVONLY
+        ):
             answer_sdp = _update_direction_in_answer(
-                answer_sdp=answer_sdp, kind=SDPMediaKind.VIDEO, old_direction=SDPDirection.SENDRECV, new_direction=SDPDirection.SENDONLY)
-        if _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.AUDIO) == SDPDirection.RECVONLY:
+                answer_sdp=answer_sdp,
+                kind=SDPMediaKind.VIDEO,
+                old_direction=SDPDirection.SENDRECV,
+                new_direction=SDPDirection.SENDONLY,
+            )
+        if (
+            _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.AUDIO)
+            == SDPDirection.RECVONLY
+        ):
             answer_sdp = _update_direction_in_answer(
-                answer_sdp=answer_sdp, kind=SDPMediaKind.AUDIO, old_direction=SDPDirection.SENDRECV, new_direction=SDPDirection.SENDONLY)
+                answer_sdp=answer_sdp,
+                kind=SDPMediaKind.AUDIO,
+                old_direction=SDPDirection.SENDRECV,
+                new_direction=SDPDirection.SENDONLY,
+            )
         return _add_foundation_to_candidates(answer_sdp)
     return answer_sdp

--- a/google_nest_sdm/webrtc_util.py
+++ b/google_nest_sdm/webrtc_util.py
@@ -32,7 +32,7 @@ def _get_media_direction(sdp: str, kind: SDPMediaKind) -> SDPDirection | None:
     # Track if we are in the desired media section
     in_media_section = False
 
-    for line in sdp.splitlines():
+    for line in sdp.split("\r\n"):
         # Check if the line is a media description line
         if line.startswith("m="):
             in_media_section = line.startswith(f"m={kind}")
@@ -72,7 +72,9 @@ def _update_direction_in_answer(
         if in_media_section and line.startswith("a="):
             # Update the direction line if it matches the kind
             if line.startswith(f"a={old_direction}"):
-                updated_sdp_lines.append(f"a={new_direction}")
+                updated_sdp_lines.append(
+                    line.replace(f"a={old_direction}", f"a={new_direction}")
+                )
                 continue
         updated_sdp_lines.append(line)
     return "\r\n".join(updated_sdp_lines)

--- a/google_nest_sdm/webrtc_util.py
+++ b/google_nest_sdm/webrtc_util.py
@@ -1,114 +1,108 @@
-# SDP Direction Constants
-DIRECTION_SENDRECV = 'sendrecv'
-DIRECTION_SENDONLY = 'sendonly'
-DIRECTION_RECVONLY = 'recvonly'
-DIRECTION_INACTIVE = 'inactive'
+"""Library with functions for manipulating WebRTC requests/responses."""
+from enum import StrEnum
 
-AVAILABLE_DIRECTIONS = [DIRECTION_SENDRECV,
-                        DIRECTION_SENDONLY,
-                        DIRECTION_RECVONLY,
-                        DIRECTION_INACTIVE]
+# SDP direction constants
+class SDPDirection(StrEnum):
+    SENDRECV = "sendrecv"
+    SENDONLY = "sendonly"
+    RECVONLY = "recvonly"
+    INACTIVE = "inactive"
 
+# SDP media kind constants
+class SDPMediaKind(StrEnum):
+    AUDIO = "audio"
+    VIDEO = "video"
+    APPLICATION = "application"
 
-class WebRTCUtility:
+def _get_media_direction(sdp: str, kind: SDPMediaKind) -> SDPDirection | None:
     """
-    This class provides methods for managing WebRTC SDP.
+    Retrieves the direction of media tracks from the SDP based on the kind (audio/video).
+
+    Args:
+        sdp (str): The SDP content
+        kind (SDPMediaKind): The kind of media track to check ('audio' or 'video').
+
+    Returns:
+        SDPMediaKind: The direction of the media track. One of 'sendrecv', 'sendonly', 'recvonly', or 'inactive'.
+    """
+    # Track if we are in the desired media section
+    in_media_section = False
+
+    for line in sdp.splitlines():
+        # Check if the line is a media description line
+        if line.startswith('m='):
+            in_media_section = line.startswith(f'm={kind}')
+        # If we're in the desired media section, check for direction
+        if in_media_section:
+            for direction in SDPDirection:
+                if line.startswith(f'a={direction}'):
+                    return direction
+    return None
+
+
+def _update_direction_in_answer(answer_sdp: str, kind: SDPMediaKind, old_direction: SDPDirection, new_direction: SDPDirection) -> str:
+    """
+    Updates the direction of a specific media track in the SDP answer if it matches a certain direction.
+
+    Args:
+        answer_sdp (str): The SDP answer in string format.
+        kind (SDPMediaKind): The kind of media track to update ('audio' or 'video').
+        old_direction (SDPDirection): The old direction to find ('sendrecv', 'sendonly', 'recvonly', 'inactive').
+        new_direction (SDPDirection): The new direction to set ('sendrecv', 'sendonly', 'recvonly', 'inactive').
+
+    Returns:
+        str: The updated SDP with the new direction.
     """
 
-    def get_media_direction(self, sdp, kind):
-        """
-        Retrieves the direction of media tracks from the SDP based on the kind (audio/video).
+    # Update the SDP
+    updated_sdp_lines = []
+    in_media_section = False
+    for line in answer_sdp.split("\r\n"):
+        if line.startswith("m="):
+            in_media_section = (kind in line)
+        if in_media_section and line.startswith("a="):
+            # Update the direction line if it matches the kind
+            if line.startswith(f"a={old_direction}"):
+                updated_sdp_lines.append(f"a={new_direction}")
+                continue
+        updated_sdp_lines.append(line)
+    return "\r\n".join(updated_sdp_lines)
 
-        Args:
-            sdp (str): The SDP content
-            kind (str): The kind of media track to check ('audio' or 'video').
 
-        Returns:
-            str: The direction of the media track. One of 'sendrecv', 'sendonly', 'recvonly', or 'inactive'.
-        """
-        # Split the SDP into lines
-        lines = sdp.splitlines()
+def _add_foundation_to_candidates(sdp: str) -> str:
+    """
+    Adds a foundation value to all ICE candidates in the SDP if it does not already exist.
 
-        # Variable to track if we are in the desired media section
-        in_media_section = False
+    Args:
+        sdp (str): The SDP in string format.
 
-        # Search for the media type and direction
-        for line in lines:
-            # Check if the line is a media description line (m=)
-            if line.startswith('m='):
-                in_media_section = (kind in line)
+    Returns:
+        str: The updated SDP with the foundation value added to ICE candidates.
+    """
+    # Add the foundation value to each ICE candidate line if not exist
+    updated_sdp_lines = []
+    index = 1
+    for line in sdp.split("\r\n"):
+        if line.startswith("a=candidate: "):
+            updated_sdp_lines.append(line.replace("a=candidate: ", f"a=candidate:{index} "))
+            index += 1
+            continue
+        updated_sdp_lines.append(line)
+    return "\r\n".join(updated_sdp_lines)
 
-            # If we're in the desired media section, check for direction
-            if in_media_section:
-                for direction in AVAILABLE_DIRECTIONS:
-                    if line.startswith(f'a={direction}'):
-                        return direction
-        return None
 
-    def update_direction_in_answer(self, answer_sdp, kind, old_direction, new_direction):
-        """
-        Updates the direction of a specific media track in the SDP answer if it matches a certain direction.
+def fix_mozilla_sdp_answer(offer_sdp: str, answer_sdp: str) -> str:
+    """Fix the answer SDP which is rejected by Firefox.
 
-        Args:
-            answer_sdp (str): The SDP answer in string format.
-            kind (str): The kind of media track to update ('audio' or 'video').
-            old_direction (str): The old direction to find ('sendrecv', 'sendonly', 'recvonly', 'inactive').
-            new_direction (str): The new direction to set ('sendrecv', 'sendonly', 'recvonly', 'inactive').
-
-        Returns:
-            str: The updated SDP with the new direction.
-        """
-
-        # Update the SDP
-        sdp_lines = answer_sdp.split('\r\n')
-        updated_sdp_lines = []
-        in_media_section = False
-
-        for line in sdp_lines:
-            if line.startswith('m='):
-                in_media_section = (kind in line)
-            if in_media_section and line.startswith('a='):
-                # Update the direction line if it matches the kind
-                if line.startswith(f'a={old_direction}'):
-                    updated_sdp_lines.append(f'a={new_direction}')
-                    continue
-            updated_sdp_lines.append(line)
-
-        updated_sdp = '\r\n'.join(updated_sdp_lines)
-        return updated_sdp
-
-    def add_foundation_to_candidates(self, sdp):
-        """
-        Adds a foundation value to all ICE candidates in the SDP if it does not already exist.
-
-        Args:
-            sdp (str): The SDP in string format.
-
-        Returns:
-            str: The updated SDP with the foundation value added to ICE candidates.
-        """
-        # Add the foundation value to each ICE candidate line
-        updated_sdp = sdp
-        index = 1
-        for line in sdp.split("\r\n"):
-            if line.startswith("a=candidate: "):
-                updated_sdp = updated_sdp.replace(line, line.replace(
-                    "a=candidate: ", "a=candidate:"+str(index)+" "))
-                index += 1
-        return updated_sdp
-
-    def fix_mozilla_sdp_answer(self, offer_sdp, answer_sdp):
-        """Fix the answer SDP which is rejected by Firefox.
-
-        1. If offer SDP is recvonly, the direction of answer SDP must not be sendrecv.
-        2. If the ICE candidates in answer SDP must contain "foundation" field.
-        """
-        if self.get_media_direction(sdp=offer_sdp, kind="video") == DIRECTION_RECVONLY:
-            answer_sdp = self.update_direction_in_answer(
-                answer_sdp=answer_sdp, kind="video", old_direction=DIRECTION_SENDRECV, new_direction=DIRECTION_SENDONLY)
-        if self.get_media_direction(sdp=offer_sdp, kind="audio") == DIRECTION_RECVONLY:
-            answer_sdp = self.update_direction_in_answer(
-                answer_sdp=answer_sdp, kind="audio", old_direction=DIRECTION_SENDRECV, new_direction=DIRECTION_SENDONLY)
-
-        answer_sdp = self.add_foundation_to_candidates(answer_sdp)
-        return answer_sdp
+    1. If offer SDP is recvonly, the direction of answer SDP must not be sendrecv.
+    2. If the ICE candidates in answer SDP must contain "foundation" field.
+    """
+    if "mozilla" in offer_sdp:
+        if _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.VIDEO) == SDPDirection.RECVONLY:
+            answer_sdp = _update_direction_in_answer(
+                answer_sdp=answer_sdp, kind=SDPMediaKind.VIDEO, old_direction=SDPDirection.SENDRECV, new_direction=SDPDirection.SENDONLY)
+        if _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.AUDIO) == SDPDirection.RECVONLY:
+            answer_sdp = _update_direction_in_answer(
+                answer_sdp=answer_sdp, kind=SDPMediaKind.AUDIO, old_direction=SDPDirection.SENDRECV, new_direction=SDPDirection.SENDONLY)
+        return _add_foundation_to_candidates(answer_sdp)
+    return answer_sdp

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -80,10 +80,10 @@ def test_fix_mozilla_sdp_answer():
         "c=IN IP4 0.0.0.0\r\n"
     )
     fixed_sdp = fix_mozilla_sdp_answer(firefox_offer_sdp, answer_sdp)
-    assert expected_answer_sdp == fixed_sdp
+    assert fixed_sdp == expected_answer_sdp
 
     fixed_sdp = fix_mozilla_sdp_answer(chrome_offer_sdp, answer_sdp)
-    assert answer_sdp == fixed_sdp
+    assert fixed_sdp == answer_sdp
 
 
 def test_get_media_direction():

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -1,17 +1,84 @@
 """Tests for WebRTC utility."""
 
 import pytest
-from google_nest_sdm.webrtc_util import DIRECTION_SENDONLY, DIRECTION_SENDRECV, WebRTCUtility
+from google_nest_sdm.webrtc_util import SDPDirection, SDPMediaKind, _add_foundation_to_candidates, _get_media_direction, _update_direction_in_answer, fix_mozilla_sdp_answer
 
-
-@pytest.fixture
-def utility():
+def test_fix_mozilla_sdp_answer():
     """
-    Fixture to create a WebRTCUtility instance for testing.
+    Test the fix in the SDP for Firefox.
     """
-    return WebRTCUtility()
-
-def test_get_media_direction(utility: WebRTCUtility):
+    firefox_offer_sdp = (
+        "v=0\r\n"
+        "o=mozilla...THIS_IS_SDPARTA-99.0 137092584186714854 0 IN IP4 0.0.0.0\r\n"
+        "m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 120 124 121 125 126 127 97 98 123 122 119\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=sendrecv\r\n"
+    )
+    answer_sdp = (
+        "v=0\r\n"
+        "o=- 0 2 IN IP4 127.0.0.1\r\n"
+        "m=audio 19305 UDP/TLS/RTP/SAVPF 109\r\n"
+        "c=IN IP4 74.125.247.118\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=candidate: 1 udp 2113939711 2001:4860:4864:4::118 19305 typ host generation 0\r\n"
+        "a=candidate: 1 tcp 2113939710 2001:4860:4864:4::118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate: 1 ssltcp 2113939709 2001:4860:4864:4::118 443 typ host generation 0\r\n"
+        "a=candidate: 1 udp 2113932031 74.125.247.118 19305 typ host generation 0\r\n"
+        "a=candidate: 1 tcp 2113932030 74.125.247.118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate: 1 ssltcp 2113932029 74.125.247.118 443 typ host generation 0\r\n"
+        "a=sendrecv\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 126 127\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=sendrecv\r\n"
+        "m=application 9 DTLS/SCTP 5000\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+    )
+    expected_answer_sdp = (
+        "v=0\r\n"
+        "o=- 0 2 IN IP4 127.0.0.1\r\n"
+        "m=audio 19305 UDP/TLS/RTP/SAVPF 109\r\n"
+        "c=IN IP4 74.125.247.118\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=candidate:1 1 udp 2113939711 2001:4860:4864:4::118 19305 typ host generation 0\r\n"
+        "a=candidate:2 1 tcp 2113939710 2001:4860:4864:4::118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate:3 1 ssltcp 2113939709 2001:4860:4864:4::118 443 typ host generation 0\r\n"
+        "a=candidate:4 1 udp 2113932031 74.125.247.118 19305 typ host generation 0\r\n"
+        "a=candidate:5 1 tcp 2113932030 74.125.247.118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate:6 1 ssltcp 2113932029 74.125.247.118 443 typ host generation 0\r\n"
+        "a=sendonly\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 126 127\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=sendonly\r\n"
+        "m=application 9 DTLS/SCTP 5000\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+    )
+    chrome_offer_sdp = (
+        "v=0\r\n"
+        "o=- 6714414228100263102 2 IN IP4 127.0.0.1\r\n"
+        "m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 35 36 37 38 102 103 104 105 106 107 108 109 127 125 39 40 41 42 43 44 45 46 47 48 112 113 114 115 116 117 118 49\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+    )
+    fixed_sdp = fix_mozilla_sdp_answer(firefox_offer_sdp, answer_sdp)
+    assert expected_answer_sdp == fixed_sdp
+    
+    fixed_sdp = fix_mozilla_sdp_answer(chrome_offer_sdp, answer_sdp)
+    assert answer_sdp == fixed_sdp
+    
+def test_get_media_direction():
     """
     Test getting the direction in the SDP.
     """
@@ -23,17 +90,20 @@ def test_get_media_direction(utility: WebRTCUtility):
         "t=0 0\r\n"
         "m=audio 49170 RTP/AVP 0\r\n"
         "a=rtpmap:0 PCMU/8000\r\n"
-        "a=sendrecv\r\n"  # Existing direction
+        "a=sendrecv\r\n"
         "m=video 51372 RTP/AVP 96\r\n"
         "a=rtpmap:96 H264/90000\r\n"
-        "a=sendrecv\r\n"
+        "a=sendonly\r\n"
     )
     
-    direction = utility.get_media_direction(sdp, 'audio')
+    direction = _get_media_direction(sdp, SDPMediaKind.AUDIO)
+    assert direction == SDPDirection.SENDRECV
+    direction = _get_media_direction(sdp, SDPMediaKind.VIDEO)
+    assert direction == SDPDirection.SENDONLY
+    direction = _get_media_direction(sdp, SDPMediaKind.APPLICATION)
+    assert direction == None
 
-    assert direction == DIRECTION_SENDRECV
-
-def test_update_direction_in_answer(utility):
+def test_update_direction_in_answer():
     """
     Test updating the direction in the SDP answer.
     """
@@ -66,13 +136,13 @@ def test_update_direction_in_answer(utility):
         "a=sendrecv\r\n"
     )
 
-    new_sdp = utility.update_direction_in_answer(
-        original_sdp, 'audio', DIRECTION_SENDRECV, DIRECTION_SENDONLY)
+    new_sdp = _update_direction_in_answer(
+        original_sdp, SDPMediaKind.AUDIO, SDPDirection.SENDRECV, SDPDirection.SENDONLY)
 
     assert new_sdp == expected_sdp
 
 
-def test_add_foundation_to_candidates(utility):
+def test_add_foundation_to_candidates():
     """
     Test adding a foundation value to ICE candidates.
     """
@@ -96,6 +166,6 @@ def test_add_foundation_to_candidates(utility):
         "a=candidate:2 1 UDP 2122260223 192.168.0.1 51372 typ host\r\n"
     )
 
-    new_sdp = utility.add_foundation_to_candidates(original_sdp)
+    new_sdp = _add_foundation_to_candidates(original_sdp)
 
     assert new_sdp == expected_sdp

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -1,7 +1,14 @@
 """Tests for WebRTC utility."""
 
-import pytest
-from google_nest_sdm.webrtc_util import SDPDirection, SDPMediaKind, _add_foundation_to_candidates, _get_media_direction, _update_direction_in_answer, fix_mozilla_sdp_answer
+from google_nest_sdm.webrtc_util import (
+    SDPDirection,
+    SDPMediaKind,
+    _add_foundation_to_candidates,
+    _get_media_direction,
+    _update_direction_in_answer,
+    fix_mozilla_sdp_answer,
+)
+
 
 def test_fix_mozilla_sdp_answer():
     """
@@ -74,10 +81,11 @@ def test_fix_mozilla_sdp_answer():
     )
     fixed_sdp = fix_mozilla_sdp_answer(firefox_offer_sdp, answer_sdp)
     assert expected_answer_sdp == fixed_sdp
-    
+
     fixed_sdp = fix_mozilla_sdp_answer(chrome_offer_sdp, answer_sdp)
     assert answer_sdp == fixed_sdp
-    
+
+
 def test_get_media_direction():
     """
     Test getting the direction in the SDP.
@@ -95,13 +103,14 @@ def test_get_media_direction():
         "a=rtpmap:96 H264/90000\r\n"
         "a=sendonly\r\n"
     )
-    
+
     direction = _get_media_direction(sdp, SDPMediaKind.AUDIO)
     assert direction == SDPDirection.SENDRECV
     direction = _get_media_direction(sdp, SDPMediaKind.VIDEO)
     assert direction == SDPDirection.SENDONLY
     direction = _get_media_direction(sdp, SDPMediaKind.APPLICATION)
-    assert direction == None
+    assert direction is None
+
 
 def test_update_direction_in_answer():
     """
@@ -137,7 +146,8 @@ def test_update_direction_in_answer():
     )
 
     new_sdp = _update_direction_in_answer(
-        original_sdp, SDPMediaKind.AUDIO, SDPDirection.SENDRECV, SDPDirection.SENDONLY)
+        original_sdp, SDPMediaKind.AUDIO, SDPDirection.SENDRECV, SDPDirection.SENDONLY
+    )
 
     assert new_sdp == expected_sdp
 

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -1,0 +1,101 @@
+"""Tests for WebRTC utility."""
+
+import pytest
+from google_nest_sdm.webrtc_util import DIRECTION_SENDONLY, DIRECTION_SENDRECV, WebRTCUtility
+
+
+@pytest.fixture
+def utility():
+    """
+    Fixture to create a WebRTCUtility instance for testing.
+    """
+    return WebRTCUtility()
+
+def test_get_media_direction(utility: WebRTCUtility):
+    """
+    Test getting the direction in the SDP.
+    """
+    sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "m=audio 49170 RTP/AVP 0\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=sendrecv\r\n"  # Existing direction
+        "m=video 51372 RTP/AVP 96\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=sendrecv\r\n"
+    )
+    
+    direction = utility.get_media_direction(sdp, 'audio')
+
+    assert direction == DIRECTION_SENDRECV
+
+def test_update_direction_in_answer(utility):
+    """
+    Test updating the direction in the SDP answer.
+    """
+    original_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "m=audio 49170 RTP/AVP 0\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=sendrecv\r\n"  # Existing direction
+        "m=video 51372 RTP/AVP 96\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=sendrecv\r\n"
+    )
+
+    # Expected result after changing the audio direction
+    expected_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "m=audio 49170 RTP/AVP 0\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=sendonly\r\n"  # Updated direction
+        "m=video 51372 RTP/AVP 96\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=sendrecv\r\n"
+    )
+
+    new_sdp = utility.update_direction_in_answer(
+        original_sdp, 'audio', DIRECTION_SENDRECV, DIRECTION_SENDONLY)
+
+    assert new_sdp == expected_sdp
+
+
+def test_add_foundation_to_candidates(utility):
+    """
+    Test adding a foundation value to ICE candidates.
+    """
+    original_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=candidate: 1 UDP 2122260223 192.168.0.1 49170 typ host\r\n"
+        "a=candidate: 1 UDP 2122260223 192.168.0.1 51372 typ host\r\n"
+    )
+
+    expected_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=candidate:1 1 UDP 2122260223 192.168.0.1 49170 typ host\r\n"
+        "a=candidate:2 1 UDP 2122260223 192.168.0.1 51372 typ host\r\n"
+    )
+
+    new_sdp = utility.add_foundation_to_candidates(original_sdp)
+
+    assert new_sdp == expected_sdp


### PR DESCRIPTION
The change is applied to offer sdp with "mozilla" only, which is Firefox.

1. The smartdevicemanagement google api returns answer sdp with a=sendrecv even offer sdp is a=recvonly
Firefox does not accept the incorrect direction
Workaround: to replace the answer sdp direction to sendonly from sendrecv

2. The smartdevicemanagement google api returns ice candidates without foundation field
Firefox cannot parse the candidate without foundation field
Workaround: assign the foundation field into the ice candidate

Ref: https://github.com/home-assistant/core/issues/103924#issuecomment-2333173718
