### PR TITLE
Workaround for Nest SDP answer bugs to pass firefox validation

### DIFF
--- a/google_nest_sdm/camera_traits.py
+++ b/google_nest_sdm/camera_traits.py
@@ -24,6 +24,7 @@ from .event import (
     EventType,
 )
 from .traits import CommandDataClass, TraitType
+from .webrtc_util import fix_mozilla_sdp_answer
 
 __all__ = [
     "CameraImageTrait",
@@ -278,6 +279,9 @@ class CameraLiveStreamTrait(DataClassDictMixin, CommandDataClass):
         results = response_data[RESULTS]
         obj = WebRtcStream.from_dict(results)
         obj._cmd = self.cmd
+        _LOGGER.debug("Received answer_sdp: %s", obj.answer_sdp)
+        obj.answer_sdp = fix_mozilla_sdp_answer(offer_sdp, obj.answer_sdp)
+        _LOGGER.debug("Return answer_sdp: %s", obj.answer_sdp)
         return obj
 
     class Config(BaseConfig):

--- a/google_nest_sdm/webrtc_util.py
+++ b/google_nest_sdm/webrtc_util.py
@@ -1,0 +1,110 @@
+"""Library with functions for manipulating WebRTC requests/responses."""
+
+from enum import StrEnum
+
+
+class SDPDirection(StrEnum):
+    """SDP direction constants."""
+
+    SENDRECV = "sendrecv"
+    SENDONLY = "sendonly"
+    RECVONLY = "recvonly"
+    INACTIVE = "inactive"
+
+
+class SDPMediaKind(StrEnum):
+    """SDP media kind constants."""
+
+    AUDIO = "audio"
+    VIDEO = "video"
+    APPLICATION = "application"
+
+
+def _get_media_direction(sdp: str, kind: SDPMediaKind) -> SDPDirection | None:
+    """Retrieves the direction of media tracks from the SDP based on the kind (audio/video)."""
+
+    # Track if we are in the desired media section
+    in_media_section = False
+
+    for line in sdp.split("\r\n"):
+        # Check if the line is a media description line
+        if line.startswith("m="):
+            in_media_section = line.startswith(f"m={kind}")
+        # If we're in the desired media section, check for direction
+        if in_media_section and line.startswith("a="):
+            for direction in SDPDirection:
+                if line.startswith(f"a={direction}"):
+                    return direction
+    return None
+
+
+def _update_direction_in_answer(
+    answer_sdp: str,
+    kind: SDPMediaKind,
+    old_direction: SDPDirection,
+    new_direction: SDPDirection,
+) -> str:
+    """Updates the direction of a specific media track in the SDP answer if it matches a certain direction."""
+
+    # Update the SDP
+    updated_sdp_lines = []
+    in_media_section = False
+    for line in answer_sdp.split("\r\n"):
+        if line.startswith("m="):
+            in_media_section = line.startswith(f"m={kind}")
+        if in_media_section and line.startswith("a="):
+            # Update the direction line if it matches the kind
+            if line.startswith(f"a={old_direction}"):
+                updated_sdp_lines.append(
+                    line.replace(f"a={old_direction}", f"a={new_direction}")
+                )
+                continue
+        updated_sdp_lines.append(line)
+    return "\r\n".join(updated_sdp_lines)
+
+
+def _add_foundation_to_candidates(sdp: str) -> str:
+    """Adds a foundation value to all ICE candidates in the SDP if it does not already exist."""
+
+    updated_sdp_lines = []
+    index = 1
+    for line in sdp.split("\r\n"):
+        if line.startswith("a=candidate: "):
+            updated_sdp_lines.append(
+                line.replace("a=candidate: ", f"a=candidate:{index} ")
+            )
+            index += 1
+            continue
+        updated_sdp_lines.append(line)
+    return "\r\n".join(updated_sdp_lines)
+
+
+def fix_mozilla_sdp_answer(offer_sdp: str, answer_sdp: str) -> str:
+    """Fix the answer SDP which is rejected by Firefox.
+
+    1. If offer SDP is recvonly, the direction of answer SDP must not be sendrecv.
+    2. If the ICE candidates in answer SDP must contain "foundation" field.
+    """
+    if "mozilla" in offer_sdp:
+        if (
+            _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.VIDEO)
+            == SDPDirection.RECVONLY
+        ):
+            answer_sdp = _update_direction_in_answer(
+                answer_sdp=answer_sdp,
+                kind=SDPMediaKind.VIDEO,
+                old_direction=SDPDirection.SENDRECV,
+                new_direction=SDPDirection.SENDONLY,
+            )
+        if (
+            _get_media_direction(sdp=offer_sdp, kind=SDPMediaKind.AUDIO)
+            == SDPDirection.RECVONLY
+        ):
+            answer_sdp = _update_direction_in_answer(
+                answer_sdp=answer_sdp,
+                kind=SDPMediaKind.AUDIO,
+                old_direction=SDPDirection.SENDRECV,
+                new_direction=SDPDirection.SENDONLY,
+            )
+        return _add_foundation_to_candidates(answer_sdp)
+    return answer_sdp

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -11,9 +11,7 @@ from google_nest_sdm.webrtc_util import (
 
 
 def test_fix_mozilla_sdp_answer() -> None:
-    """
-    Test the fix in the SDP for Firefox.
-    """
+    """Test the fix in the SDP for Firefox."""
     firefox_offer_sdp = (
         "v=0\r\n"
         "o=mozilla...THIS_IS_SDPARTA-99.0 137092584186714854 0 IN IP4 0.0.0.0\r\n"
@@ -87,9 +85,7 @@ def test_fix_mozilla_sdp_answer() -> None:
 
 
 def test_get_media_direction() -> None:
-    """
-    Test getting the direction in the SDP.
-    """
+    """Test getting the direction in the SDP."""
     sdp = (
         "v=0\r\n"
         "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
@@ -113,9 +109,7 @@ def test_get_media_direction() -> None:
 
 
 def test_update_direction_in_answer() -> None:
-    """
-    Test updating the direction in the SDP answer.
-    """
+    """Test updating the direction in the SDP answer."""
     original_sdp = (
         "v=0\r\n"
         "o=- 123456 654321 IN IP4 127.0.0.1\r\n"

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -10,7 +10,7 @@ from google_nest_sdm.webrtc_util import (
 )
 
 
-def test_fix_mozilla_sdp_answer():
+def test_fix_mozilla_sdp_answer() -> None:
     """
     Test the fix in the SDP for Firefox.
     """
@@ -86,7 +86,7 @@ def test_fix_mozilla_sdp_answer():
     assert fixed_sdp == answer_sdp
 
 
-def test_get_media_direction():
+def test_get_media_direction() -> None:
     """
     Test getting the direction in the SDP.
     """
@@ -112,7 +112,7 @@ def test_get_media_direction():
     assert direction is None
 
 
-def test_update_direction_in_answer():
+def test_update_direction_in_answer() -> None:
     """
     Test updating the direction in the SDP answer.
     """
@@ -152,7 +152,7 @@ def test_update_direction_in_answer():
     assert new_sdp == expected_sdp
 
 
-def test_add_foundation_to_candidates():
+def test_add_foundation_to_candidates() -> None:
     """
     Test adding a foundation value to ICE candidates.
     """

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -153,9 +153,7 @@ def test_update_direction_in_answer() -> None:
 
 
 def test_add_foundation_to_candidates() -> None:
-    """
-    Test adding a foundation value to ICE candidates.
-    """
+    """Test adding a foundation value to ICE candidates."""
     original_sdp = (
         "v=0\r\n"
         "o=- 123456 654321 IN IP4 127.0.0.1\r\n"

--- a/tests/test_webrtc_util.py
+++ b/tests/test_webrtc_util.py
@@ -1,0 +1,181 @@
+"""Tests for WebRTC utility."""
+
+from google_nest_sdm.webrtc_util import (
+    SDPDirection,
+    SDPMediaKind,
+    _add_foundation_to_candidates,
+    _get_media_direction,
+    _update_direction_in_answer,
+    fix_mozilla_sdp_answer,
+)
+
+
+def test_fix_mozilla_sdp_answer():
+    """
+    Test the fix in the SDP for Firefox.
+    """
+    firefox_offer_sdp = (
+        "v=0\r\n"
+        "o=mozilla...THIS_IS_SDPARTA-99.0 137092584186714854 0 IN IP4 0.0.0.0\r\n"
+        "m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 120 124 121 125 126 127 97 98 123 122 119\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=sendrecv\r\n"
+    )
+    answer_sdp = (
+        "v=0\r\n"
+        "o=- 0 2 IN IP4 127.0.0.1\r\n"
+        "m=audio 19305 UDP/TLS/RTP/SAVPF 109\r\n"
+        "c=IN IP4 74.125.247.118\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=candidate: 1 udp 2113939711 2001:4860:4864:4::118 19305 typ host generation 0\r\n"
+        "a=candidate: 1 tcp 2113939710 2001:4860:4864:4::118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate: 1 ssltcp 2113939709 2001:4860:4864:4::118 443 typ host generation 0\r\n"
+        "a=candidate: 1 udp 2113932031 74.125.247.118 19305 typ host generation 0\r\n"
+        "a=candidate: 1 tcp 2113932030 74.125.247.118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate: 1 ssltcp 2113932029 74.125.247.118 443 typ host generation 0\r\n"
+        "a=sendrecv\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 126 127\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=sendrecv\r\n"
+        "m=application 9 DTLS/SCTP 5000\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+    )
+    expected_answer_sdp = (
+        "v=0\r\n"
+        "o=- 0 2 IN IP4 127.0.0.1\r\n"
+        "m=audio 19305 UDP/TLS/RTP/SAVPF 109\r\n"
+        "c=IN IP4 74.125.247.118\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=candidate:1 1 udp 2113939711 2001:4860:4864:4::118 19305 typ host generation 0\r\n"
+        "a=candidate:2 1 tcp 2113939710 2001:4860:4864:4::118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate:3 1 ssltcp 2113939709 2001:4860:4864:4::118 443 typ host generation 0\r\n"
+        "a=candidate:4 1 udp 2113932031 74.125.247.118 19305 typ host generation 0\r\n"
+        "a=candidate:5 1 tcp 2113932030 74.125.247.118 19305 typ host tcptype passive generation 0\r\n"
+        "a=candidate:6 1 ssltcp 2113932029 74.125.247.118 443 typ host generation 0\r\n"
+        "a=sendonly\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 126 127\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+        "a=sendonly\r\n"
+        "m=application 9 DTLS/SCTP 5000\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+    )
+    chrome_offer_sdp = (
+        "v=0\r\n"
+        "o=- 6714414228100263102 2 IN IP4 127.0.0.1\r\n"
+        "m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 35 36 37 38 102 103 104 105 106 107 108 109 127 125 39 40 41 42 43 44 45 46 47 48 112 113 114 115 116 117 118 49\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=recvonly\r\n"
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+    )
+    fixed_sdp = fix_mozilla_sdp_answer(firefox_offer_sdp, answer_sdp)
+    assert fixed_sdp == expected_answer_sdp
+
+    fixed_sdp = fix_mozilla_sdp_answer(chrome_offer_sdp, answer_sdp)
+    assert fixed_sdp == answer_sdp
+
+
+def test_get_media_direction():
+    """
+    Test getting the direction in the SDP.
+    """
+    sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "m=audio 49170 RTP/AVP 0\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=sendrecv\r\n"
+        "m=video 51372 RTP/AVP 96\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=sendonly\r\n"
+    )
+
+    direction = _get_media_direction(sdp, SDPMediaKind.AUDIO)
+    assert direction == SDPDirection.SENDRECV
+    direction = _get_media_direction(sdp, SDPMediaKind.VIDEO)
+    assert direction == SDPDirection.SENDONLY
+    direction = _get_media_direction(sdp, SDPMediaKind.APPLICATION)
+    assert direction is None
+
+
+def test_update_direction_in_answer():
+    """
+    Test updating the direction in the SDP answer.
+    """
+    original_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "m=audio 49170 RTP/AVP 0\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=sendrecv\r\n"  # Existing direction
+        "m=video 51372 RTP/AVP 96\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=sendrecv\r\n"
+    )
+
+    # Expected result after changing the audio direction
+    expected_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "m=audio 49170 RTP/AVP 0\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=sendonly\r\n"  # Updated direction
+        "m=video 51372 RTP/AVP 96\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=sendrecv\r\n"
+    )
+
+    new_sdp = _update_direction_in_answer(
+        original_sdp, SDPMediaKind.AUDIO, SDPDirection.SENDRECV, SDPDirection.SENDONLY
+    )
+
+    assert new_sdp == expected_sdp
+
+
+def test_add_foundation_to_candidates():
+    """
+    Test adding a foundation value to ICE candidates.
+    """
+    original_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=candidate: 1 UDP 2122260223 192.168.0.1 49170 typ host\r\n"
+        "a=candidate: 1 UDP 2122260223 192.168.0.1 51372 typ host\r\n"
+    )
+
+    expected_sdp = (
+        "v=0\r\n"
+        "o=- 123456 654321 IN IP4 127.0.0.1\r\n"
+        "s=Test\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=candidate:1 1 UDP 2122260223 192.168.0.1 49170 typ host\r\n"
+        "a=candidate:2 1 UDP 2122260223 192.168.0.1 51372 typ host\r\n"
+    )
+
+    new_sdp = _add_foundation_to_candidates(original_sdp)
+
+    assert new_sdp == expected_sdp


### PR DESCRIPTION
The change is applied to offer sdp with "mozilla" only, which is Firefox.

1. The smartdevicemanagement google api returns answer sdp with a=sendrecv even offer sdp is a=recvonly
Firefox does not accept the incorrect direction
Workaround: to replace the answer sdp direction to sendonly from sendrecv

2. The smartdevicemanagement google api returns ice candidates without foundation field
Firefox cannot parse the candidate without foundation field
Workaround: assign the foundation field into the ice candidate

Ref: https://github.com/home-assistant/core/issues/103924#issuecomment-2333173718