### PR TITLE
Update subscription and topic assumptions given upcoming breaking changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = google_nest_sdm
-version = 5.0.1
+version = 6.0.0
 description = Library for the Google Nest SDM API
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Prepare for upcoming breaking changes where the topic name will no longer be fixed. This updates the subscriber to take a topic name as input, but still assumes it was created by the caller.