### PR TITLE
Fix for AdminClient API to not deal directly with hosts

### DIFF
--- a/google_nest_sdm/admin_client.py
+++ b/google_nest_sdm/admin_client.py
@@ -29,9 +29,10 @@ __all__ = [
     "EligibleSubscriptions",
     "validate_subscription_name",
     "validate_topic_name",
+    "PUBSUB_API_HOST",
 ]
 
-API_HOST_FORMAT = "https://pubsub.googleapis.com/v1/"
+PUBSUB_API_HOST = "https://pubsub.googleapis.com/v1/"
 SDM_MANAGED_TOPIC_FORMAT = (
     "projects/sdm-prod/topics/enterprise-{device_access_project_id}"
 )
@@ -109,11 +110,14 @@ class AdminClient:
     """Admin client for the Google Nest SDM API."""
 
     def __init__(
-        self, auth: AbstractAuth, cloud_project_id: str, host: str | None = None
+        self, auth: AbstractAuth, cloud_project_id: str,
     ) -> None:
-        """Initialize the admin client."""
+        """Initialize the admin client.
+        
+        The auth instance must be configured with the correct host (PUBSUB_API_HOST).
+        """
         self._cloud_project_id = cloud_project_id
-        self._auth = auth.with_host(host if host is not None else API_HOST_FORMAT)
+        self._auth = auth
 
     async def create_topic(self, topic_name: str) -> None:
         """Create a pubsub topic for the project."""

--- a/google_nest_sdm/auth.py
+++ b/google_nest_sdm/auth.py
@@ -101,10 +101,6 @@ class AbstractAuth(ABC):
         self._websession = websession
         self._host = host
 
-    def with_host(self, host: str) -> AbstractAuth:
-        """Return a new instance with a different host."""
-        return self.__class__(self._websession, host)
-
     @abstractmethod
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = google_nest_sdm
-version = 6.1.0
+version = 6.1.1
 description = Library for the Google Nest SDM API
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_admin_client.py
+++ b/tests/test_admin_client.py
@@ -26,7 +26,7 @@ def mock_admin_client(
 
     async def _make_admin_client() -> AdminClient:
         mock_auth = await auth_client()
-        return AdminClient(mock_auth, GOOGLE_CLOUD_CONSOLE_PROJECT_ID, host="")
+        return AdminClient(mock_auth, GOOGLE_CLOUD_CONSOLE_PROJECT_ID)
 
     return _make_admin_client
 


### PR DESCRIPTION
Fix for AdminClient API to not deal directly with hosts. The existing API does not work given it can't know the AbstractAuth constructor type in order to re-create it.  While this is a breaking change, marking as a patch given the API never worked.