### PR TITLE
Overhaul Nest Pub/sub Subscription API and implementation as fully async

### DIFF
--- a/google_nest_sdm/diagnostics.py
+++ b/google_nest_sdm/diagnostics.py
@@ -67,11 +67,13 @@ class Diagnostics:
 SUBSCRIBER_DIAGNOSTICS = Diagnostics()
 EVENT_DIAGNOSTICS = Diagnostics()
 EVENT_MEDIA_DIAGNOSTICS = Diagnostics()
+STREAMING_MANAGER_DIAGNOSTICS = Diagnostics()
 
 MAP = {
     "subscriber": SUBSCRIBER_DIAGNOSTICS,
     "event": EVENT_DIAGNOSTICS,
     "event_media": EVENT_MEDIA_DIAGNOSTICS,
+    "streaming_manager": STREAMING_MANAGER_DIAGNOSTICS,
 }
 
 

--- a/google_nest_sdm/google_nest.py
+++ b/google_nest_sdm/google_nest.py
@@ -271,12 +271,12 @@ async def RunTool(args: argparse.Namespace, user_creds: Credentials) -> None:
             else:
                 sub_callback = SubscribeCallback(args.output_type)
                 subscriber.set_update_callback(sub_callback.async_handle_event)
-            await subscriber.start_async()
+            unsub = await subscriber.start_async()
             try:
                 while True:
                     await asyncio.sleep(10)
             except KeyboardInterrupt:
-                subscriber.stop_async()
+                unsub()
 
         # All other commands require a device_id
         device: Device | None = await api.async_get_device(args.device_id)

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -3,22 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
+import datetime
 import enum
-import json
 import logging
 import re
 import time
-from abc import ABC, abstractmethod
 from typing import Awaitable, Callable
 
-from aiohttp.client_exceptions import ClientError
-from google.api_core.exceptions import GoogleAPIError, NotFound, Unauthenticated
-from google.auth.exceptions import RefreshError, GoogleAuthError, TransportError
-from google.auth.transport.requests import Request
-from google.cloud import pubsub_v1
-from google.oauth2.credentials import Credentials
-from google.protobuf.duration_pb2 import Duration
 
 from .auth import AbstractAuth
 from .device_manager import DeviceManager
@@ -26,12 +17,11 @@ from .diagnostics import SUBSCRIBER_DIAGNOSTICS as DIAGNOSTICS
 from .event import EventMessage
 from .event_media import CachePolicy
 from .exceptions import (
-    AuthException,
     ConfigurationException,
-    SubscriberException,
     ApiException,
 )
 from .google_nest_api import GoogleNestAPI
+from .streaming_manager import StreamingManager, Message
 
 __all__ = [
     "GoogleNestSubscriber",
@@ -47,21 +37,16 @@ EXPECTED_SUBSCRIBER_REGEXP = re.compile("projects/.*/subscriptions/.*")
 # Used to catch a topic misconfiguration
 EXPECTED_TOPIC_REGEXP = re.compile("projects/.*/topics/.*")
 
-WATCHDOG_CHECK_INTERVAL_SECONDS = 10
-
-# Restart the subscriber after some delay, with exponential backoff
-WATCHDOG_RESTART_DELAY_MIN_SECONDS = 10
-WATCHDOG_RESTART_DELAY_MAX_SECONDS = 300
-# Reset watchdog backoff
-WATCHDOG_RESET_THRESHOLD_SECONDS = 60
-
 DEFAULT_MESSAGE_RETENTION_SECONDS = 15 * 60  # 15 minutes
 
 MESSAGE_ACK_TIMEOUT_SECONDS = 30.0
 
 NEW_SUBSCRIBER_TIMEOUT_SECONDS = 30.0
-NEW_SUBSCRIBER_THREAD_TIMEOUT_SECONDS = 120.0
 GET_SUBSCRIPTION_TIMEOUT = 30.0
+
+MIN_BACKOFF_INTERVAL = datetime.timedelta(seconds=10)
+MAX_BACKOFF_INTERVAL = datetime.timedelta(minutes=10)
+BACKOFF_MULTIPLIER = 1.5
 
 
 # Note: Users of non-prod instances will have to manually configure a topic
@@ -125,210 +110,6 @@ def _validate_subscription_name(subscription_name: str) -> None:
         )
 
 
-def _validate_topic_name(topic_name: str) -> None:
-    """Validates that a topic name is correct.
-
-    Raises ConfigurationException on failure.
-    """
-    if not EXPECTED_TOPIC_REGEXP.match(topic_name):
-        DIAGNOSTICS.increment("topic_name_invalid")
-        _LOGGER.debug("Topic name did not match pattern: %s", topic_name)
-        raise ConfigurationException(
-            "Subscription misconfigured. Expected topic name to "
-            f"match '{EXPECTED_TOPIC_REGEXP.pattern}' but was "
-            f"'{topic_name}'."
-        )
-
-
-def refresh_creds(creds: Credentials) -> Credentials:
-    """Refresh credentials.
-
-    This is not part of the subscriber API, exposed only to facilitate testing.
-    """
-    try:
-        creds.refresh(Request())
-    except RefreshError as err:
-        raise AuthException(f"Authentication refresh failure: {err}") from err
-    except TransportError as err:
-        raise SubscriberException(
-            f"Connectivity error during authentication refresh: {err}"
-        ) from err
-    except GoogleAuthError as err:
-        raise SubscriberException(
-            f"Error during authentication refresh: {err}"
-        ) from err
-    return creds
-
-
-class AbstractSubscriberFactory(ABC):
-    """Abstract class for creating a subscriber, to facilitate testing."""
-
-    @abstractmethod
-    async def async_create_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        topic_name: str,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        """Creates a subscription name if it does not already exist."""
-
-    @abstractmethod
-    async def async_delete_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        """Deletes a subscription."""
-
-    @abstractmethod
-    async def async_new_subscriber(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        loop: asyncio.AbstractEventLoop,
-        async_callback: Callable[
-            [pubsub_v1.subscriber.message.Message], Awaitable[None]
-        ],
-    ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-        """Create a new event subscriber."""
-
-
-class DefaultSubscriberFactory(AbstractSubscriberFactory):
-    """Default implementation that creates Google Pubsub subscriber."""
-
-    async def async_create_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        topic_name: str,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        """Creates a subscription name if it does not already exist."""
-        _validate_subscription_name(subscription_name)
-        _validate_topic_name(topic_name)
-        await loop.run_in_executor(
-            None,
-            self._create_subscription,
-            creds,
-            subscription_name,
-            topic_name,
-        )
-
-    def _create_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        topic_name: str,
-    ) -> None:
-        """Creates a subscription name if it does not already exist."""
-        subscriber = pubsub_v1.SubscriberClient(credentials=creds)
-
-        subscription = None
-        try:
-            subscription = subscriber.get_subscription(subscription=subscription_name)
-        except NotFound:
-            _LOGGER.debug("Existing subscription not found; Creating")
-        if subscription:
-            if subscription.topic != topic_name:
-                raise ConfigurationException(
-                    "Subscription misconfigured. Expected topic name to "
-                    f"match '{topic_name}' but was "
-                    f"'{subscription.topic}'. Please delete in cloud "
-                    "console and it will be re-created."
-                )
-            # Valid subscription already exists; No-op
-            return
-
-        message_retention_duration = Duration()
-        message_retention_duration.FromSeconds(DEFAULT_MESSAGE_RETENTION_SECONDS)
-        subscription_request = {
-            "name": subscription_name,
-            "topic": topic_name,
-            "message_retention_duration": message_retention_duration,
-        }
-        _LOGGER.debug(f"Creating subscription: {subscription_request}")
-        subscriber.create_subscription(request=subscription_request)
-
-    async def async_delete_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        """Creates a subscription name if it does not already exist."""
-        await loop.run_in_executor(
-            None,
-            self._delete_subscription,
-            creds,
-            subscription_name,
-        )
-
-    def _delete_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-    ) -> None:
-        """Deletes a subscription."""
-        creds = refresh_creds(creds)
-        subscriber = pubsub_v1.SubscriberClient(credentials=creds)
-        _LOGGER.debug(f"Deleting subscription '{subscription_name}'")
-        subscriber.delete_subscription(subscription=subscription_name)
-
-    async def async_new_subscriber(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        loop: asyncio.AbstractEventLoop,
-        async_callback: Callable[
-            [pubsub_v1.subscriber.message.Message], Awaitable[None]
-        ],
-    ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-        """Create a new subscriber with a blocking to async bridge."""
-
-        def callback_wrapper(message: pubsub_v1.subscriber.message.Message) -> None:
-            future: concurrent.futures.Future = asyncio.run_coroutine_threadsafe(
-                async_callback(message), loop
-            )
-            future.result(NEW_SUBSCRIBER_TIMEOUT_SECONDS)
-
-        return await loop.run_in_executor(
-            None,
-            self._new_subscriber,
-            creds,
-            subscription_name,
-            callback_wrapper,
-        )
-
-
-    def _new_subscriber(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        callback_wrapper: Callable[[pubsub_v1.subscriber.message.Message], None],
-    ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-        """Issue a command to verify subscriber creds are correct."""
-        _LOGGER.debug("Creating subscriber '%s'", subscription_name)
-        creds = refresh_creds(creds)
-        _LOGGER.debug("Subscriber credentials refreshed")
-        subscriber = pubsub_v1.SubscriberClient(credentials=creds)
-        subscription = subscriber.get_subscription(
-            subscription=subscription_name,
-            timeout=GET_SUBSCRIPTION_TIMEOUT
-        )
-        _LOGGER.debug("Found subscription: %s", subscription_name)
-        if subscription.topic:
-            _validate_topic_name(subscription.topic)
-            _LOGGER.debug(
-                "Subscriber '%s' configured on topic '%s'",
-                subscription_name,
-                subscription.topic,
-            )
-        _LOGGER.debug("Starting subscriber future '%s'", subscription_name)
-        return subscriber.subscribe(subscription_name, callback_wrapper)
-
-
 class GoogleNestSubscriber:
     """Subscribe to events from the Google Nest feed."""
 
@@ -336,40 +117,21 @@ class GoogleNestSubscriber:
         self,
         auth: AbstractAuth,
         project_id: str,
-        subscriber_name: str,
-        subscriber_factory: AbstractSubscriberFactory = DefaultSubscriberFactory(),
-        topic_name: str | None = None,
-        loop: asyncio.AbstractEventLoop | None = None,
-        watchdog_check_interval_seconds: float = WATCHDOG_CHECK_INTERVAL_SECONDS,
-        watchdog_restart_delay_min_seconds: float = WATCHDOG_RESTART_DELAY_MIN_SECONDS,
-    ):
+        subscription_name: str,
+    ) -> None:
         """Initialize the subscriber for the specified topic."""
         self._auth = auth
-        self._subscriber_name = subscriber_name
-        if topic_name is None:
-            self._topic_name = TOPIC_FORMAT.format(project_id=project_id)
-        else:
-            self._topic_name = topic_name
+        self._subscription_name = subscription_name
         self._project_id = project_id
         self._api = GoogleNestAPI(auth, project_id)
-        self._loop = loop or asyncio.get_running_loop()
         self._device_manager_task: asyncio.Task[DeviceManager] | None = None
-        self._subscriber_factory = subscriber_factory
-        self._subscriber_future: (
-            pubsub_v1.subscriber.futures.StreamingPullFuture | None
-        ) = None  # noqa: E501
         self._callback: Callable[[EventMessage], Awaitable[None]] | None = None
-        self._healthy = True
-        self._watchdog_check_interval_seconds = watchdog_check_interval_seconds
-        self._watchdog_restart_delay_min_seconds = watchdog_restart_delay_min_seconds
-        self._watchdog_restart_delay_seconds = watchdog_restart_delay_min_seconds
-        self._watchdog_task: asyncio.Task | None = None
         self._cache_policy = CachePolicy()
 
     @property
-    def subscriber_id(self) -> str:
+    def subscription_name(self) -> str:
         """Return the configured subscriber name."""
-        return self._subscriber_name
+        return self._subscription_name
 
     @property
     def project_id(self) -> str:
@@ -380,7 +142,7 @@ class GoogleNestSubscriber:
         self, target: Callable[[EventMessage], Awaitable[None]]
     ) -> None:
         """Register a callback invoked when new messages are received.
-        
+
         If the event is associated with media, then the callback will only
         be invoked once the media has been fetched.
         """
@@ -388,142 +150,23 @@ class GoogleNestSubscriber:
         if self._device_manager_task and self._device_manager_task.done():
             self._device_manager_task.result().set_update_callback(target)
 
-    async def create_subscription(self) -> None:
-        """Create the subscription if it does not already exist."""
-        _validate_subscription_name(self._subscriber_name)
-        DIAGNOSTICS.increment("create_subscription.attempt")
-        try:
-            creds = await self._auth.async_get_creds()
-        except ClientError as err:
-            DIAGNOSTICS.increment("create_subscription.creds_error")
-            raise AuthException(f"Access token failure: {err}") from err
-        try:
-            await self._subscriber_factory.async_create_subscription(
-                creds,
-                self._subscriber_name,
-                self._topic_name,
-                self._loop,
-            )
-        except NotFound as err:
-            DIAGNOSTICS.increment("create_subscription.not_found")
-            raise ConfigurationException(
-                f"Failed to create subscription '{self._subscriber_name}' "
-                + "(cloud project id incorrect?)"
-            ) from err
-        except Unauthenticated as err:
-            DIAGNOSTICS.increment("create_subscription.unauthenticated")
-            raise AuthException("Failed to authenticate when creating subscription: {err}") from err
-        except GoogleAPIError as err:
-            DIAGNOSTICS.increment("create_subscription.api_error")
-            raise SubscriberException(
-                f"Failed to create subscription '{self._subscriber_name}': {err}"
-            ) from err
+    async def start_async(self) -> Callable[[], None]:
+        """Start the subscription.
 
-    async def delete_subscription(self) -> None:
-        """Delete the subscription."""
-        DIAGNOSTICS.increment("delete_subscription.attempt")
-        try:
-            creds = await self._auth.async_get_creds()
-        except ClientError as err:
-            DIAGNOSTICS.increment("delete_subscription.creds_error")
-            raise AuthException(f"Access token failure: {err}") from err
-
-        try:
-            await self._subscriber_factory.async_delete_subscription(
-                creds, self._subscriber_name, self._loop
-            )
-        except NotFound:
-            DIAGNOSTICS.increment("delete_subscription.not_found")
-            # No-op if subscription was already deleted
-            return
-        except Unauthenticated as err:
-            DIAGNOSTICS.increment("delete_subscription.unauthenticated")
-            raise AuthException("Failed to authenticate when deleting subscription: {err}") from err
-        except GoogleAPIError as err:
-            DIAGNOSTICS.increment("delete_subscription.api_error")
-            raise SubscriberException(
-                f"Failed to delete subscription '{self._subscriber_name}': {err}"
-            ) from err
-
-    async def start_async(self) -> None:
-        """Start the subscriber."""
-        _LOGGER.debug("Starting subscriber %s", self._subscriber_name)
+        Returns a callable used to stop/cancel the subscription. Received
+        messages are passed to the callback provided to `set_update_callback`.
+        """
+        _validate_subscription_name(self._subscription_name)
+        _LOGGER.debug("Starting subscription %s", self._subscription_name)
         DIAGNOSTICS.increment("start")
-        _validate_subscription_name(self._subscriber_name)
-        try:
-            creds = await self._auth.async_get_creds()
-        except ClientError as err:
-            DIAGNOSTICS.increment("start.creds_error")
-            raise AuthException(f"Access token failure: {err}") from err
 
-        try:
-            async with asyncio.timeout(NEW_SUBSCRIBER_THREAD_TIMEOUT_SECONDS):        
-                self._subscriber_future = (
-                    await self._subscriber_factory.async_new_subscriber(
-                        creds, self._subscriber_name, self._loop, self._async_message_callback_with_timeout
-                    )
-                )
-        except asyncio.TimeoutError as err:
-            _LOGGER.debug("Failed to create subscriber '%s' with timeout: %s", self._subscriber_name, err)
-            DIAGNOSTICS.increment("start.timeout_error")
-            raise SubscriberException(
-                f"Failed to create subscriber '{self._subscriber_name}' with timeout: {err}"
-            ) from err
-        except NotFound as err:
-            _LOGGER.debug("Failed to create subscriber '%s' id was not found: %s", self._subscriber_name, err)
-            DIAGNOSTICS.increment("start.not_found_error")
-            raise ConfigurationException(
-                f"Failed to create subscriber '{self._subscriber_name}' id was not found"
-            ) from err
-        except Unauthenticated as err:
-            _LOGGER.debug("Failed to authenticate subscriber: %s", err)
-            DIAGNOSTICS.increment("start.unauthenticated")
-            raise AuthException("Failed to authenticate subscriber: {err}") from err
-        except GoogleAPIError as err:
-            _LOGGER.debug("Failed to create subscriber '%s' with api error: %s", self._subscriber_name, err)
-            DIAGNOSTICS.increment("start.api_error")
-            raise SubscriberException(
-                f"Failed to create subscriber '{self._subscriber_name}' with api error: {err}"
-            ) from err
-
-        if not self._healthy:
-            _LOGGER.debug("Subscriber reconnected")
-            self._healthy = True
-            self._watchdog_restart_delay_seconds = (
-                self._watchdog_restart_delay_min_seconds
-            )
-        if self._watchdog_check_interval_seconds > 0:
-            self._watchdog_task = asyncio.create_task(self._watchdog())
-        if self._subscriber_future:
-            self._subscriber_future.add_done_callback(self._done_callback)
-
-    async def _watchdog(self) -> None:
-        """Background task that watches the subscriber and restarts it."""
-        _LOGGER.debug("Starting background watchdog thread")
-        while True:
-            if self._subscriber_future and self._subscriber_future.done():
-                _LOGGER.debug(
-                    "Watchdog: subscriber shut down; restarting in %s seconds",
-                    self._watchdog_restart_delay_seconds,
-                )
-                await asyncio.sleep(self._watchdog_restart_delay_seconds)
-                self._watchdog_restart_delay_seconds *= 2
-                self._watchdog_restart_delay_seconds = max(
-                    self._watchdog_restart_delay_seconds,
-                    WATCHDOG_RESTART_DELAY_MAX_SECONDS,
-                )
-                await self.start_async()
-            await asyncio.sleep(self._watchdog_check_interval_seconds)
-
-    def stop_async(self) -> None:
-        """Tell the subscriber to start shutting down."""
-        DIAGNOSTICS.increment("stop")
-        if self._device_manager_task:
-            self._device_manager_task.cancel()
-        if self._watchdog_task:
-            self._watchdog_task.cancel()
-        if self._subscriber_future:
-            self._subscriber_future.cancel()
+        stream = StreamingManager(
+            auth=self._auth,
+            subscription_name=self._subscription_name,
+            callback=self._async_message_callback_with_timeout,
+        )
+        await stream.start()
+        return stream.stop
 
     @property
     def cache_policy(self) -> CachePolicy:
@@ -536,7 +179,6 @@ class GoogleNestSubscriber:
             self._device_manager_task = asyncio.create_task(
                 self._async_create_device_manager()
             )
-        assert self._device_manager_task
         return await self._device_manager_task
 
     async def _async_create_device_manager(self) -> DeviceManager:
@@ -553,19 +195,7 @@ class GoogleNestSubscriber:
             device_manager.set_update_callback(self._callback)
         return device_manager
 
-    def _done_callback(
-        self, future: pubsub_v1.subscriber.futures.StreamingPullFuture
-    ) -> None:
-        """Teardown subscriber."""
-        if future.exception():
-            ex = future.exception()
-            if self._healthy:
-                self._healthy = False
-            _LOGGER.debug("Subscriber disconnected, will restart: %s: %s", type(ex), ex)
-
-    async def _async_message_callback_with_timeout(
-        self, message: pubsub_v1.subscriber.message.Message
-    ) -> None:
+    async def _async_message_callback_with_timeout(self, message: Message) -> None:
         """Handle a received message."""
         try:
             async with asyncio.timeout(MESSAGE_ACK_TIMEOUT_SECONDS):
@@ -574,12 +204,9 @@ class GoogleNestSubscriber:
             DIAGNOSTICS.increment("message_ack_timeout")
             raise TimeoutError("Message ack timeout processing message") from err
 
-    async def _async_message_callback(
-        self, message: pubsub_v1.subscriber.message.Message
-    ) -> None:
+    async def _async_message_callback(self, message: Message) -> None:
         """Handle a received message."""
-        payload = json.loads(bytes.decode(message.data))
-        event = EventMessage.create_event(payload, self._auth)
+        event = EventMessage.create_event(message.payload, self._auth)
         recv = time.time()
         latency_ms = int((recv - event.timestamp.timestamp()) * 1000)
         DIAGNOSTICS.elapsed("message_received", latency_ms)
@@ -601,10 +228,9 @@ class GoogleNestSubscriber:
                 await _hack_refresh_devices(self._api, device_manager)
             else:
                 await device_manager.async_handle_event(event)
-            message.ack()
 
-        ack_latency_ms = int((time.time() - recv) * 1000)
-        DIAGNOSTICS.elapsed("message_acked", ack_latency_ms)
+        process_latency_ms = int((time.time() - recv) * 1000)
+        DIAGNOSTICS.elapsed("message_processed", process_latency_ms)
 
 
 def _is_invalid_thermostat_trait_update(event: EventMessage) -> bool:

--- a/google_nest_sdm/google_nest_subscriber.py
+++ b/google_nest_sdm/google_nest_subscriber.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import enum
 import logging
 import re
@@ -34,20 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 # Used to catch invalid subscriber id
 EXPECTED_SUBSCRIBER_REGEXP = re.compile("projects/.*/subscriptions/.*")
 
-# Used to catch a topic misconfiguration
-EXPECTED_TOPIC_REGEXP = re.compile("projects/.*/topics/.*")
-
-DEFAULT_MESSAGE_RETENTION_SECONDS = 15 * 60  # 15 minutes
-
 MESSAGE_ACK_TIMEOUT_SECONDS = 30.0
-
-NEW_SUBSCRIBER_TIMEOUT_SECONDS = 30.0
-GET_SUBSCRIPTION_TIMEOUT = 30.0
-
-MIN_BACKOFF_INTERVAL = datetime.timedelta(seconds=10)
-MAX_BACKOFF_INTERVAL = datetime.timedelta(minutes=10)
-BACKOFF_MULTIPLIER = 1.5
-
 
 # Note: Users of non-prod instances will have to manually configure a topic
 TOPIC_FORMAT = "projects/sdm-prod/topics/enterprise-{project_id}"

--- a/google_nest_sdm/streaming_manager.py
+++ b/google_nest_sdm/streaming_manager.py
@@ -1,0 +1,160 @@
+"""Subscriber for the Smart Device Management event based API."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import json
+from typing import Awaitable, Callable, AsyncIterable, Any, TYPE_CHECKING
+
+from google import pubsub_v1
+
+from .auth import AbstractAuth
+from .diagnostics import STREAMING_MANAGER_DIAGNOSTICS as DIAGNOSTICS
+from .exceptions import (
+    GoogleNestException,
+)
+from .subscriber_client import SubscriberClient
+
+_LOGGER = logging.getLogger(__name__)
+
+MESSAGE_ACK_TIMEOUT_SECONDS = 30.0
+
+NEW_SUBSCRIBER_TIMEOUT_SECONDS = 30.0
+
+MIN_BACKOFF_INTERVAL = datetime.timedelta(seconds=10)
+MAX_BACKOFF_INTERVAL = datetime.timedelta(minutes=10)
+BACKOFF_MULTIPLIER = 1.5
+
+
+class Message:
+    """A message from the Pub/Sub stream."""
+
+    def __init__(self, message: pubsub_v1.types.PubsubMessage) -> None:
+        """Initialize the message."""
+        self._message = message
+        self._payload: dict[str, Any] | None = None
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        """Get the payload of the message."""
+        if self._payload is None:
+            self._payload = json.loads(bytes.decode(self._message.data)) or {}
+        return self._payload
+
+    @classmethod
+    def from_data(cls, data: dict[str, Any]) -> Message:
+        """Create a message from an object for testing."""
+        return cls(encode_pubsub_message(data))
+
+
+def encode_pubsub_message(data: dict[str, Any]) -> pubsub_v1.types.PubsubMessage:
+    """Encode a message for Pub/Sub."""
+    return pubsub_v1.types.PubsubMessage(data=bytes(json.dumps(data), "utf-8"))
+
+
+class StreamingManager:
+    """Client for the Google Nest subscriber."""
+
+    def __init__(
+        self,
+        auth: AbstractAuth,
+        subscription_name: str,
+        callback: Callable[[Message], Awaitable[None]],
+    ) -> None:
+        """Initialize the client."""
+        self._subscription_name = subscription_name
+        self._callback = callback
+        self._background_task: asyncio.Task | None = None
+        self._subscriber_client = SubscriberClient(auth, subscription_name)
+        self._stream: AsyncIterable[pubsub_v1.types.StreamingPullResponse] | None = None
+
+    async def start(self) -> None:
+        """Start the subscription background task and wait for initial startup."""
+        DIAGNOSTICS.increment("start")
+        self._stream = await self._connect(allow_retries=False)
+        loop = asyncio.get_event_loop()
+        self._background_task = loop.create_task(self._run_task())
+
+    def stop(self) -> None:
+        _LOGGER.debug("Stopping subscription %s", self._subscription_name)
+        DIAGNOSTICS.increment("stop")
+        if self._background_task:
+            self._background_task.cancel()
+
+    async def _run_task(self) -> None:
+        """"""
+        try:
+            await self._run()
+        except asyncio.CancelledError:
+            _LOGGER.debug("Subscription loop cancelled")
+        except Exception as err:
+            _LOGGER.error("Uncaught error in subscription loop: %s", err)
+            DIAGNOSTICS.increment("uncaught_exception")
+
+    async def _run(self) -> None:
+        """Run the subscription loop."""
+        DIAGNOSTICS.increment("run")
+        while True:
+            _LOGGER.debug("Subscriber connected and waiting for messages")
+            if TYPE_CHECKING:
+                assert self._stream is not None
+            try:
+                async for response in self._stream:
+                    _LOGGER.debug(
+                        "Received %s messages", len(response.received_messages)
+                    )
+                    ack_ids = []
+                    for received_message in response.received_messages:
+                        if await self._process_message(received_message.message):
+                            ack_ids.append(received_message.ack_id)
+
+                    if ack_ids:
+                        _LOGGER.debug("Acknowledging %s messages", len(ack_ids))
+                        try:
+                            await self._subscriber_client.ack_messages(ack_ids)
+                        except GoogleNestException as err:
+                            _LOGGER.debug("Error while acknowledging messages: %s", err)
+            except GoogleNestException as err:
+                _LOGGER.debug("Error while processing messages: %s", err)
+                DIAGNOSTICS.increment("exception")
+
+            _LOGGER.debug("Reconnecting stream")
+            self._stream = await self._connect(allow_retries=True)
+
+    async def _connect(
+        self, allow_retries: bool = True
+    ) -> AsyncIterable[pubsub_v1.types.StreamingPullResponse] | None:
+        """Connect to the streaming pull."""
+        backoff = MIN_BACKOFF_INTERVAL
+        while True:
+            _LOGGER.debug("Connecting with streaming pull")
+            DIAGNOSTICS.increment("connect")
+            try:
+                return await self._subscriber_client.streaming_pull()
+            except GoogleNestException as err:
+                if not allow_retries:
+                    raise err
+                _LOGGER.warning("Error while reconnecting stream: %s", err)
+                backoff = min(backoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_INTERVAL)
+                DIAGNOSTICS.increment("backoff")
+
+            _LOGGER.debug("Reconnecting in %s seconds", backoff.total_seconds())
+            await asyncio.sleep(backoff.total_seconds())
+
+    async def _process_message(self, message: pubsub_v1.types.PubsubMessage) -> bool:
+        """Process an incoming message from the stream."""
+        DIAGNOSTICS.increment("process_message")
+        try:
+            async with asyncio.timeout(MESSAGE_ACK_TIMEOUT_SECONDS):
+                await self._callback(Message(message))
+                return True
+        except TimeoutError as err:
+            DIAGNOSTICS.increment("process_message_timeout")
+            _LOGGER.error("Unexpected timeout while processing message: %s", err)
+            return False
+        except Exception as err:
+            DIAGNOSTICS.increment("process_message_exception")
+            _LOGGER.error("Uncaught error while processing message: %s", err)
+            return False

--- a/google_nest_sdm/subscriber_client.py
+++ b/google_nest_sdm/subscriber_client.py
@@ -75,7 +75,7 @@ def exception_handler[
                     "Failed to authenticate subscriber in %s: %s", func_name, err
                 )
                 DIAGNOSTICS.increment(f"{func_name}.unauthenticated")
-                raise AuthException("Failed to authenticate subscriber: {err}") from err
+                raise AuthException(f"Failed to authenticate {func_name}: {err}") from err
             except GoogleAPIError as err:
                 _LOGGER.debug("API error in %s: %s", func_name, err)
                 DIAGNOSTICS.increment(f"{func_name}.api_error")

--- a/google_nest_sdm/subscriber_client.py
+++ b/google_nest_sdm/subscriber_client.py
@@ -1,0 +1,150 @@
+"""Pub/sub subscriber client library."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, AsyncIterable, Any
+from collections.abc import AsyncIterator
+
+from aiohttp.client_exceptions import ClientError
+from google.api_core.exceptions import GoogleAPIError, NotFound, Unauthenticated
+from google.auth.exceptions import RefreshError, GoogleAuthError, TransportError
+from google.auth.transport.requests import Request
+from google import pubsub_v1
+from google.oauth2.credentials import Credentials
+
+from .auth import AbstractAuth
+from .diagnostics import SUBSCRIBER_DIAGNOSTICS as DIAGNOSTICS
+from .exceptions import (
+    AuthException,
+    ConfigurationException,
+    SubscriberException,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+RPC_TIMEOUT_SECONDS = 10.0
+STREAM_ACK_TIMEOUT_SECONDS = 30.0
+
+
+def refresh_creds(creds: Credentials) -> Credentials:
+    """Refresh credentials.
+
+    This is not part of the subscriber API, exposed only to facilitate testing.
+    """
+    try:
+        creds.refresh(Request())
+    except RefreshError as err:
+        raise AuthException(f"Authentication refresh failure: {err}") from err
+    except TransportError as err:
+        raise SubscriberException(
+            f"Connectivity error during authentication refresh: {err}"
+        ) from err
+    except GoogleAuthError as err:
+        raise SubscriberException(
+            f"Error during authentication refresh: {err}"
+        ) from err
+    return creds
+
+
+def exception_handler[
+    _T: Any
+](func_name: str) -> Callable[..., Callable[..., Awaitable[_T]]]:
+    """Wrap a function with exception handling."""
+
+    def wrapped(func: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
+
+        async def wrapped_func(*args: Any, **kwargs: Any) -> _T:
+            try:
+                async with asyncio.timeout(RPC_TIMEOUT_SECONDS):
+                    return await func(*args, **kwargs)
+            except asyncio.TimeoutError as err:
+                _LOGGER.debug("Timeout in %s: %s", func_name, err)
+                DIAGNOSTICS.increment(f"{func_name}.timeout")
+                raise SubscriberException(f"Timeout in {func_name}") from err
+            except NotFound as err:
+                _LOGGER.debug("NotFound error in %s: %s", func_name, err)
+                DIAGNOSTICS.increment(f"{func_name}.not_found_error")
+                raise ConfigurationException(
+                    f"NotFound error calling {func_name}: {err}"
+                ) from err
+            except Unauthenticated as err:
+                _LOGGER.debug(
+                    "Failed to authenticate subscriber in %s: %s", func_name, err
+                )
+                DIAGNOSTICS.increment(f"{func_name}.unauthenticated")
+                raise AuthException("Failed to authenticate subscriber: {err}") from err
+            except GoogleAPIError as err:
+                _LOGGER.debug("API error in %s: %s", func_name, err)
+                DIAGNOSTICS.increment(f"{func_name}.api_error")
+                raise SubscriberException(
+                    f"API error when calling {func_name}: {err}"
+                ) from err
+            except Exception as err:
+                _LOGGER.debug("Uncaught error in %s: %s", func_name, err)
+                DIAGNOSTICS.increment(f"{func_name}.api_error")
+                raise SubscriberException(
+                    f"Unexpected error when calling {func_name}: {err}"
+                ) from err
+
+        return wrapped_func
+
+    return wrapped
+
+
+class SubscriberClient:
+    """Pub/sub subscriber client library."""
+
+    def __init__(
+        self,
+        auth: AbstractAuth,
+        subscription_name: str,
+    ) -> None:
+        """Initialize the SubscriberClient."""
+        self._auth = auth
+        self._subscription_name = subscription_name
+        self._client: pubsub_v1.SubscriberAsyncClient | None = None
+        self._creds: Credentials | None = None
+
+    async def _async_get_client(self) -> pubsub_v1.SubscriberAsyncClient:
+        """Create the Pub/Sub client library."""
+        if self._client is None or self._creds is None or self._creds.expired:
+            try:
+                creds = await self._auth.async_get_creds()
+            except ClientError as err:
+                DIAGNOSTICS.increment("create_subscription.creds_error")
+                raise AuthException(f"Access token failure: {err}") from err
+            self._creds = creds
+            self._client = pubsub_v1.SubscriberAsyncClient(credentials=self._creds)
+        return self._client
+
+    @exception_handler(func_name="streaming_pull")
+    async def streaming_pull(
+        self,
+    ) -> AsyncIterable[pubsub_v1.types.StreamingPullResponse]:
+        """Start the streaming pull."""
+
+        async def _request_generator() -> AsyncIterator[pubsub_v1.StreamingPullRequest]:
+            while True:
+                yield pubsub_v1.StreamingPullRequest(
+                    subscription=self._subscription_name,
+                    stream_ack_deadline_seconds=STREAM_ACK_TIMEOUT_SECONDS,
+                )
+
+        client = await self._async_get_client()
+        _LOGGER.debug("Sending streaming pull request for %s", self._subscription_name)
+        return await client.streaming_pull(requests=_request_generator())
+
+    @exception_handler("acknowledge")
+    async def ack_messages(self, ack_ids: list[str]) -> None:
+        """Acknowledge messages."""
+        if not ack_ids:
+            return
+        client = await self._async_get_client()
+        _LOGGER.debug("Acking %s messages", len(ack_ids))
+        await client.acknowledge(
+            subscription=self._subscription_name,
+            ack_ids=ack_ids,
+        )

--- a/tests/test_google_nest_subscriber.py
+++ b/tests/test_google_nest_subscriber.py
@@ -1,124 +1,58 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from typing import Any, Awaitable, Callable, Dict, Optional
-from unittest.mock import create_autospec, Mock, patch
+import logging
+from typing import Any, Awaitable, Callable, Dict
+from collections.abc import Generator
+from unittest.mock import Mock, patch
 
 import aiohttp
 import pytest
-from google.auth.exceptions import RefreshError, GoogleAuthError, TransportError
-from google.api_core.exceptions import ClientError, Unauthenticated
-from google.cloud import pubsub_v1
-from google.oauth2.credentials import Credentials
 
 from google_nest_sdm import diagnostics
 from google_nest_sdm.auth import AbstractAuth
 from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import (
-    AuthException,
     ConfigurationException,
-    SubscriberException,
 )
 from google_nest_sdm.google_nest_subscriber import (
-    AbstractSubscriberFactory,
     GoogleNestSubscriber,
     get_api_env,
-    refresh_creds,
 )
+from google_nest_sdm.streaming_manager import Message, StreamingManager
 
 from .conftest import DeviceHandler, EventCallback, StructureHandler, assert_diagnostics
+
+_LOGGER = logging.getLogger(__name__)
 
 PROJECT_ID = "project-id1"
 SUBSCRIPTION_NAME = "projects/some-project-id/subscriptions/subscriber-id1"
 
 
-class FakeSubscriberFactory(AbstractSubscriberFactory):
-    def __init__(self) -> None:
-        self.tasks: Optional[Any] = None
+@pytest.fixture(name="streaming_manager", autouse=True)
+def mock_streaming_manager() -> Generator[Mock, None, None]:
+    """Patch StreamingManager and capture the callback."""
+    with patch(
+        "google_nest_sdm.google_nest_subscriber.StreamingManager", spec=StreamingManager
+    ) as mock_manager:
+        # Use side_effect to capture the callback
+        def mock_init(**kwargs: Any) -> Mock:
+            mock_manager.callback = kwargs["callback"]
+            return mock_manager
 
-    async def async_create_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        topic_name: str,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        return
-
-    async def async_delete_subscription(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        return
-
-    async def async_new_subscriber(
-        self,
-        creds: Credentials,
-        subscription_name: str,
-        loop: asyncio.AbstractEventLoop,
-        async_callback: Callable[
-            [pubsub_v1.subscriber.message.Message], Awaitable[None]
-        ],
-    ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-        self._async_callback = async_callback
-        if self.tasks:
-            return asyncio.create_task(self.tasks.pop(0)())
-        return None
-
-    async def async_push_event(self, event: Dict[str, Any]) -> None:
-        message = create_autospec(pubsub_v1.subscriber.message.Message, instance=True)
-        message.data = json.dumps(event).encode()
-        return await self._async_callback(message)
-
-
-@pytest.fixture
-def subscriber_factory() -> FakeSubscriberFactory:
-    return FakeSubscriberFactory()
+        mock_manager.side_effect = mock_init
+        yield mock_manager
 
 
 @pytest.fixture
 def subscriber_client(
-    subscriber_factory: FakeSubscriberFactory,
     auth_client: Callable[[], Awaitable[AbstractAuth]],
 ) -> Callable[[], Awaitable[GoogleNestSubscriber]]:
-    async def make_subscriber(
-        factory: Optional[AbstractSubscriberFactory] = subscriber_factory,
-    ) -> GoogleNestSubscriber:
+    async def make_subscriber() -> GoogleNestSubscriber:
         auth = await auth_client()
-        assert factory
-        return GoogleNestSubscriber(auth, PROJECT_ID, SUBSCRIPTION_NAME, factory)
+        return GoogleNestSubscriber(auth, PROJECT_ID, SUBSCRIPTION_NAME)
 
     return make_subscriber
-
-
-async def test_refresh_creds() -> None:
-    """Test low level refresh errors."""
-    mock_refresh = Mock()
-    mock_creds = Mock()
-    mock_creds.refresh = mock_refresh
-    refresh_creds(mock_creds)
-    assert mock_refresh.call_count == 1
-
-
-@pytest.mark.parametrize(
-    ("raised", "expected"),
-    [
-        (RefreshError(), AuthException),
-        (TransportError(), SubscriberException),
-        (GoogleAuthError(), SubscriberException),
-    ],
-)
-async def test_refresh_creds_error(raised: Exception, expected: Any) -> None:
-    """Test low level refresh errors."""
-    mock_refresh = Mock()
-    mock_refresh.side_effect = raised
-    mock_creds = Mock()
-    mock_creds.refresh = mock_refresh
-    with pytest.raises(expected):
-        refresh_creds(mock_creds)
 
 
 async def test_subscribe_no_events(
@@ -131,45 +65,12 @@ async def test_subscribe_no_events(
     structure_handler.add_structure()
 
     subscriber = await subscriber_client()
-    await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
     devices = device_manager.devices
     assert device_id1 in devices
     assert devices[device_id1].type == "sdm.devices.types.device-type1"
     assert device_id2 in devices
     assert devices[device_id2].type == "sdm.devices.types.device-type2"
-    subscriber.stop_async()
-
-
-async def test_subscribe_device_manager(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
-) -> None:
-    device_id1 = device_handler.add_device(device_type="sdm.devices.types.device-type1")
-    device_id2 = device_handler.add_device(device_type="sdm.devices.types.device-type2")
-    structure_handler.add_structure()
-
-    subscriber = await subscriber_client()
-    await subscriber.start_async()
-    device_manager = await subscriber.async_get_device_manager()
-    devices = device_manager.devices
-    assert device_id1 in devices
-    assert devices[device_id1].type == "sdm.devices.types.device-type1"
-    assert device_id2 in devices
-    assert devices[device_id2].type == "sdm.devices.types.device-type2"
-    subscriber.stop_async()
-
-    assert_diagnostics(
-        diagnostics.get_diagnostics(),
-        {
-            "subscriber": {
-                "start": 1,
-                "stop": 1,
-            },
-        },
-    )
 
 
 async def test_subscribe_update_trait(
@@ -177,7 +78,7 @@ async def test_subscribe_update_trait(
     device_handler: DeviceHandler,
     structure_handler: StructureHandler,
     subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
-    subscriber_factory: FakeSubscriberFactory,
+    streaming_manager: Mock,
 ) -> None:
     device_id = device_handler.add_device(
         traits={
@@ -190,7 +91,7 @@ async def test_subscribe_update_trait(
 
     subscriber = await subscriber_client()
     subscriber.cache_policy.event_cache_size = 5
-    await subscriber.start_async()
+    unsub = await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
     devices = device_manager.devices
     assert device_id in devices
@@ -211,23 +112,22 @@ async def test_subscribe_update_trait(
         },
         "userId": "AVPHwEv75jw4WFshx6-XhBLhotn3r8IXOzCusfSOn5QU",
     }
-    await subscriber_factory.async_push_event(event)
+    await streaming_manager.callback(Message.from_data(event))
 
     devices = device_manager.devices
     assert device_id in devices
     device = devices[device_id]
     trait = device.traits["sdm.devices.traits.Connectivity"]
     assert "OFFLINE" == trait.status
-    subscriber.stop_async()
+    unsub()
 
     assert_diagnostics(
         diagnostics.get_diagnostics(),
         {
             "subscriber": {
-                "message_acked_count": 1,
+                "message_processed_count": 1,
                 "message_received_count": 1,
                 "start": 1,
-                "stop": 1,
             },
         },
     )
@@ -258,210 +158,13 @@ async def test_subscribe_device_manager_init(
     subscriber = await subscriber_client()
     start_async = subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
-    await start_async
+    unsub = await start_async
     devices = device_manager.devices
     assert device_id1 in devices
     assert devices[device_id1].type == "sdm.devices.types.device-type1"
     assert device_id2 in devices
     assert devices[device_id2].type == "sdm.devices.types.device-type2"
-    subscriber.stop_async()
-
-
-async def test_subscriber_watchdog(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    auth_client: Callable[[], Awaitable[AbstractAuth]],
-    subscriber_factory: FakeSubscriberFactory,
-) -> None:
-    # Waits for the test to wake up the background thread
-    event1 = asyncio.Event()
-
-    async def task1() -> None:
-        await event1.wait()
-
-    event2 = asyncio.Event()
-
-    async def task2() -> None:
-        event2.set()
-
-    subscriber_factory.tasks = [task1, task2]
-
-    auth = await auth_client()
-    subscriber = GoogleNestSubscriber(
-        auth,
-        PROJECT_ID,
-        SUBSCRIPTION_NAME,
-        subscriber_factory=subscriber_factory,
-        watchdog_check_interval_seconds=0.1,
-        watchdog_restart_delay_min_seconds=0.1,
-    )
-    assert len(subscriber_factory.tasks) == 2
-    await subscriber.start_async()
-    assert len(subscriber_factory.tasks) == 1
-    # Wait for the subscriber to start, then shut it down
-    event1.set()
-    # Block until the new subscriber starts, and notifies this to wake up
-    await event2.wait()
-    assert len(subscriber_factory.tasks) == 0
-    subscriber.stop_async()
-
-
-async def test_subscriber_timeout(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    subscriber_client: Callable[
-        [Optional[AbstractSubscriberFactory]], Awaitable[GoogleNestSubscriber]
-    ],
-) -> None:
-    class FailingFactory(FakeSubscriberFactory):
-        async def async_new_subscriber(
-            self,
-            creds: Credentials,
-            subscription_name: str,
-            loop: asyncio.AbstractEventLoop,
-            async_callback: Callable[
-                [pubsub_v1.subscriber.message.Message], Awaitable[None]
-            ],
-        ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-            raise asyncio.TimeoutError("Some error")
-
-    subscriber = await subscriber_client(FailingFactory())
-
-    with pytest.raises(SubscriberException):
-        await subscriber.start_async()
-    subscriber.stop_async()
-
-    assert_diagnostics(
-        diagnostics.get_diagnostics(),
-        {
-            "subscriber": {
-                "start": 1,
-                "start.timeout_error": 1,
-                "stop": 1,
-            },
-        },
-    )
-async def test_subscriber_error(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    subscriber_client: Callable[
-        [Optional[AbstractSubscriberFactory]], Awaitable[GoogleNestSubscriber]
-    ],
-) -> None:
-    class FailingFactory(FakeSubscriberFactory):
-        async def async_new_subscriber(
-            self,
-            creds: Credentials,
-            subscription_name: str,
-            loop: asyncio.AbstractEventLoop,
-            async_callback: Callable[
-                [pubsub_v1.subscriber.message.Message], Awaitable[None]
-            ],
-        ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-            raise ClientError("Some error")  # type: ignore
-
-    subscriber = await subscriber_client(FailingFactory())
-
-    with pytest.raises(SubscriberException):
-        await subscriber.start_async()
-    subscriber.stop_async()
-
-    assert_diagnostics(
-        diagnostics.get_diagnostics(),
-        {
-            "subscriber": {
-                "start": 1,
-                "start.api_error": 1,
-                "stop": 1,
-            },
-        },
-    )
-
-
-async def test_subscriber_auth_error(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    subscriber_client: Callable[
-        [Optional[AbstractSubscriberFactory]], Awaitable[GoogleNestSubscriber]
-    ],
-) -> None:
-    class FailingFactory(FakeSubscriberFactory):
-        async def async_new_subscriber(
-            self,
-            creds: Credentials,
-            subscription_name: str,
-            loop: asyncio.AbstractEventLoop,
-            async_callback: Callable[
-                [pubsub_v1.subscriber.message.Message], Awaitable[None]
-            ],
-        ) -> pubsub_v1.subscriber.futures.StreamingPullFuture:
-            raise Unauthenticated("Auth failure")  # type: ignore
-
-    subscriber = await subscriber_client(FailingFactory())
-    with pytest.raises(AuthException):
-        await subscriber.start_async()
-    subscriber.stop_async()
-
-
-async def test_auth_refresh(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    refreshing_auth_client: Callable[[], Awaitable[AbstractAuth]],
-    subscriber_factory: FakeSubscriberFactory,
-) -> None:
-    async def auth_handler(request: aiohttp.web.Request) -> aiohttp.web.Response:
-        return aiohttp.web.json_response({"token": "updated-token"})
-
-    device_handler.token = "updated-token"
-    device_id = device_handler.add_device(device_type="sdm.devices.types.device-type1")
-
-    structure_handler.token = "updated-token"
-    structure_handler.add_structure()
-
-    app.router.add_get("/refresh-auth", auth_handler)
-
-    auth = await refreshing_auth_client()
-    subscriber = GoogleNestSubscriber(
-        auth, PROJECT_ID, SUBSCRIPTION_NAME, subscriber_factory
-    )
-    await subscriber.start_async()
-    device_manager = await subscriber.async_get_device_manager()
-    devices = device_manager.devices
-    assert device_id in devices
-    assert devices[device_id].type == "sdm.devices.types.device-type1"
-    subscriber.stop_async()
-
-
-async def test_auth_refresh_error(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    refreshing_auth_client: Callable[[], Awaitable[AbstractAuth]],
-    subscriber_factory: FakeSubscriberFactory,
-) -> None:
-    async def auth_handler(request: aiohttp.web.Request) -> aiohttp.web.Response:
-        return aiohttp.web.Response(status=401)
-
-    device_handler.token = "updated-token"
-    device_handler.add_device()
-    structure_handler.token = "updated-token"
-    structure_handler.add_structure()
-
-    app.router.add_get("/refresh-auth", auth_handler)
-
-    auth = await refreshing_auth_client()
-    subscriber = GoogleNestSubscriber(
-        auth, PROJECT_ID, SUBSCRIPTION_NAME, subscriber_factory
-    )
-
-    with pytest.raises(AuthException):
-        await subscriber.start_async()
-    subscriber.stop_async()
+    unsub()
 
 
 async def test_subscriber_id_error(
@@ -469,16 +172,16 @@ async def test_subscriber_id_error(
     device_handler: DeviceHandler,
     structure_handler: StructureHandler,
     auth_client: Callable[[], Awaitable[AbstractAuth]],
-    subscriber_factory: FakeSubscriberFactory,
 ) -> None:
     auth = await auth_client()
 
     subscriber = GoogleNestSubscriber(
-        auth, PROJECT_ID, "bad-subscriber-id", subscriber_factory
+        auth,
+        PROJECT_ID,
+        "bad-subscriber-id",
     )
     with pytest.raises(ConfigurationException):
         await subscriber.start_async()
-    subscriber.stop_async()
 
 
 async def test_subscribe_thread_update(
@@ -486,7 +189,7 @@ async def test_subscribe_thread_update(
     device_handler: DeviceHandler,
     structure_handler: StructureHandler,
     subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
-    subscriber_factory: FakeSubscriberFactory,
+    streaming_manager: Mock,
 ) -> None:
     device_id = device_handler.add_device(
         traits={
@@ -498,7 +201,7 @@ async def test_subscribe_thread_update(
 
     subscriber = await subscriber_client()
     subscriber.cache_policy.event_cache_size = 5
-    await subscriber.start_async()
+    unsub = await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
     devices = device_manager.devices
     assert device_id in devices
@@ -532,7 +235,7 @@ async def test_subscribe_thread_update(
         ],
         "eventThreadState": "STARTED",
     }
-    await subscriber_factory.async_push_event(event)
+    await streaming_manager.callback(Message.from_data(event))
 
     # Verify the message is received. The full content is verified below.
     assert len(subscriber_callback.messages) == 1
@@ -566,7 +269,7 @@ async def test_subscribe_thread_update(
         ],
         "eventThreadState": "ENDED",
     }
-    await subscriber_factory.async_push_event(event)
+    await streaming_manager.callback(Message.from_data(event))
 
     assert len(subscriber_callback.messages) == 1
     message = subscriber_callback.messages[0]
@@ -586,7 +289,7 @@ async def test_subscribe_thread_update(
     message = device_callback.messages[1]
     assert message.event_id == "7f29332e-5537-47f6-a3f9-840c307340f5"
 
-    subscriber.stop_async()
+    unsub()
 
 
 async def test_subscribe_thread_update_new_events(
@@ -594,7 +297,7 @@ async def test_subscribe_thread_update_new_events(
     device_handler: DeviceHandler,
     structure_handler: StructureHandler,
     subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
-    subscriber_factory: FakeSubscriberFactory,
+    streaming_manager: Mock,
 ) -> None:
     device_id = device_handler.add_device(
         traits={
@@ -607,7 +310,8 @@ async def test_subscribe_thread_update_new_events(
 
     subscriber = await subscriber_client()
     subscriber.cache_policy.event_cache_size = 5
-    await subscriber.start_async()
+
+    unsub = await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
     devices = device_manager.devices
     assert device_id in devices
@@ -641,7 +345,8 @@ async def test_subscribe_thread_update_new_events(
         ],
         "eventThreadState": "STARTED",
     }
-    await subscriber_factory.async_push_event(event)
+    await streaming_manager.callback(Message.from_data(event))
+    assert len(callback.messages) == 1
 
     # End the thread (resource update is identical)
     event2 = {
@@ -671,7 +376,7 @@ async def test_subscribe_thread_update_new_events(
         ],
         "eventThreadState": "ENDED",
     }
-    await subscriber_factory.async_push_event(event2)
+    await streaming_manager.callback(Message.from_data(event2))
 
     assert len(callback.messages) == 2
     message: EventMessage = callback.messages[0]
@@ -696,17 +401,15 @@ async def test_subscribe_thread_update_new_events(
     # Device also receives the same messages
     assert len(device_callback.messages) == 2
 
-    subscriber.stop_async()
+    unsub()
 
 
 async def test_message_ack_timeout(
     app: aiohttp.web.Application,
     device_handler: DeviceHandler,
     structure_handler: StructureHandler,
-    subscriber_factory: FakeSubscriberFactory,
-    subscriber_client: Callable[
-        [Optional[AbstractSubscriberFactory]], Awaitable[GoogleNestSubscriber]
-    ],
+    streaming_manager: Mock,
+    subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
     fake_event_message: Callable[[Dict[str, Any]], EventMessage],
 ) -> None:
 
@@ -719,9 +422,9 @@ async def test_message_ack_timeout(
     )
     structure_id = structure_handler.add_structure()
 
-    subscriber = await subscriber_client(subscriber_factory)
+    subscriber = await subscriber_client()
     subscriber.cache_policy.event_cache_size = 5
-    await subscriber.start_async()
+    unsub = await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
     devices = device_manager.devices
     assert device_id in devices
@@ -744,9 +447,9 @@ async def test_message_ack_timeout(
         "google_nest_sdm.google_nest_subscriber.MESSAGE_ACK_TIMEOUT_SECONDS", 0.01
     ):
         with pytest.raises(TimeoutError, match="Message ack timeout"):
-            await subscriber_factory.async_push_event(event)
+            await streaming_manager.callback(Message.from_data(event))
 
-    subscriber.stop_async()
+    unsub()
 
 
 async def test_refresh_hack_on_invalid_thermostat_traits(
@@ -754,9 +457,9 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
     device_handler: DeviceHandler,
     structure_handler: StructureHandler,
     subscriber_client: Callable[[], Awaitable[GoogleNestSubscriber]],
-    subscriber_factory: FakeSubscriberFactory,
+    streaming_manager: Mock,
 ) -> None:
-    """Test that when invalid thermostat traits are ignored and triggers a refresh."""
+    """Test that invalid thermostat traits are ignored and triggers a refresh."""
 
     device_id = device_handler.add_device(
         traits={
@@ -782,7 +485,7 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
 
     subscriber = await subscriber_client()
     subscriber.cache_policy.event_cache_size = 5
-    await subscriber.start_async()
+    unsub = await subscriber.start_async()
     device_manager = await subscriber.async_get_device_manager()
 
     device = device_manager.devices.get(device_id)
@@ -816,28 +519,30 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
 
     # Simulate a case where the nest publisher sends an invalid message. This
     # will be ignored and will trigger another state refresh.
-    await subscriber_factory.async_push_event(
-        {
-            "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
-            "timestamp": "2019-01-01T00:00:01Z",
-            "resourceUpdate": {
-                "name": device.name,
-                "traits": {
-                    "sdm.devices.traits.ThermostatMode": {
-                        "mode": "OFF",
-                        "availableModes": ["OFF"],
+    await streaming_manager.callback(
+        Message.from_data(
+            {
+                "eventId": "0120ecc7-3b57-4eb4-9941-91609f189fb4",
+                "timestamp": "2019-01-01T00:00:01Z",
+                "resourceUpdate": {
+                    "name": device.name,
+                    "traits": {
+                        "sdm.devices.traits.ThermostatMode": {
+                            "mode": "OFF",
+                            "availableModes": ["OFF"],
+                        },
+                        "sdm.devices.traits.ThermostatEco": {
+                            "availableModes": ["OFF", "MANUAL_ECO"],
+                            "mode": "OFF",
+                            "heatCelsius": 0.0,
+                            "coolCelsius": 0.0,
+                        },
+                        "sdm.devices.traits.ThermostatTemperatureSetpoint": {},
                     },
-                    "sdm.devices.traits.ThermostatEco": {
-                        "availableModes": ["OFF", "MANUAL_ECO"],
-                        "mode": "OFF",
-                        "heatCelsius": 0.0,
-                        "coolCelsius": 0.0,
-                    },
-                    "sdm.devices.traits.ThermostatTemperatureSetpoint": {},
                 },
-            },
-            "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
-        }
+                "userId": "AVPHwEuBfnPOnTqzVFT4IONX2Qqhu9EJ4ubO-bNnQ-yi",
+            }
+        )
     )
 
     device = device_manager.devices.get(device_id)
@@ -863,6 +568,8 @@ async def test_refresh_hack_on_invalid_thermostat_traits(
     trait = device.traits.get("sdm.devices.traits.ThermostatTemperatureSetpoint")
     assert trait
     assert trait.heat_celsius == 20.0
+
+    unsub()
 
 
 def test_api_env_prod() -> None:
@@ -893,27 +600,3 @@ def test_api_env_preprod() -> None:
 def test_api_env_invalid() -> None:
     with pytest.raises(ValueError):
         get_api_env("invalid")
-
-
-
-async def test_topic_id(
-    app: aiohttp.web.Application,
-    device_handler: DeviceHandler,
-    structure_handler: StructureHandler,
-    auth_client: Callable[[], Awaitable[AbstractAuth]],
-    subscriber_factory: FakeSubscriberFactory,
-) -> None:
-    """Test that creates a client with a specific topic id."""
-
-    auth = await auth_client()
-    # Just exercise the constructor
-    subscriber = GoogleNestSubscriber(
-        auth,
-        PROJECT_ID,
-        subscriber_name=SUBSCRIPTION_NAME,
-        topic_name="projects/some-project-id/topics/some-topic-id",
-        subscriber_factory=subscriber_factory,
-        watchdog_check_interval_seconds=0.1,
-        watchdog_restart_delay_min_seconds=0.1,
-    )
-    await subscriber.create_subscription()

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Dict
+from unittest.mock import Mock, patch, AsyncMock
+from collections.abc import AsyncGenerator, Generator
+import datetime
+
+import pytest
+from google.api_core.exceptions import ClientError, Unauthenticated, GoogleAPIError
+from google.cloud import pubsub_v1
+
+from google_nest_sdm import diagnostics
+from google_nest_sdm.auth import AbstractAuth
+from google_nest_sdm.exceptions import (
+    AuthException,
+    SubscriberException,
+)
+from google_nest_sdm.streaming_manager import (
+    StreamingManager,
+    Message,
+    encode_pubsub_message,
+)
+
+from .conftest import DeviceHandler, assert_diagnostics
+
+_LOGGER = logging.getLogger(__name__)
+
+PROJECT_ID = "project-id1"
+SUBSCRIPTION_NAME = "projects/some-project-id/subscriptions/subscriber-id1"
+
+
+class MessageQueue:
+    """A queue of messages to simulate a pubsub subscription."""
+
+    def __init__(self) -> None:
+        self.event = asyncio.Event()
+        self.messages: list[pubsub_v1.types.PubsubMessage] = []
+        self.errors: list[Exception] = []
+
+    async def async_push_events(
+        self, events: list[Dict[str, Any]], sleep: bool = True
+    ) -> None:
+        """Push an event into the queue."""
+        for event in events:
+            _LOGGER.debug("Pushing event %s", event)
+            self.messages.append(encode_pubsub_message(event))
+        self.event.set()
+        if sleep:
+            await asyncio.sleep(0)
+
+    async def async_push_errors(self, errors: list[Exception]) -> None:
+        """Push an event into the queue."""
+        _LOGGER.debug("Pushing errors")
+        self.errors.extend(errors)
+        self.event.set()
+        await asyncio.sleep(0)
+
+    async def __aiter__(
+        self,
+    ) -> AsyncGenerator[pubsub_v1.types.StreamingPullResponse, None]:
+        """Get a message from the queue."""
+        while True:
+            _LOGGER.debug("Waiting for message")
+            await self.event.wait()
+            if self.errors:
+                _LOGGER.debug("Raising error for StreamingPullResponse")
+                raise self.errors.pop(0)
+            messages = [*self.messages]
+            self.messages.clear()
+            self.event.clear()
+            _LOGGER.debug("Streaming Pull Response has %d messages", len(messages))
+            yield pubsub_v1.types.StreamingPullResponse(
+                received_messages=[
+                    pubsub_v1.types.ReceivedMessage(
+                        ack_id="1",
+                        message=message,
+                        delivery_attempt=1,
+                    )
+                    for message in messages
+                ]
+            )
+
+
+@pytest.fixture(name="message_queue")
+def mock_pubsub_queue() -> MessageQueue:
+    """Fixture to allow tests to add messages to the pubsub feed."""
+    return MessageQueue()
+
+
+@pytest.fixture(name="pull_exception")
+def mock_pull_exception() -> Exception | list[Exception] | None:
+    """Fixture to allow tests to add messages to the pubsub feed."""
+    return None
+
+
+@pytest.fixture(name="callback_exception")
+def mock_callback_exception() -> Exception | None:
+    """Fixture to allow tests to add messages to the pubsub feed."""
+    return None
+
+
+@pytest.fixture(name="subscriber_async_client")
+def mock_subscriber_async_client(
+    message_queue: MessageQueue, pull_exception: Exception | list[Exception] | None
+) -> Generator[Mock, None, None]:
+    """Fixture to mock the subscriber."""
+
+    with patch(
+        "google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient"
+    ) as mock:
+
+        def pull_result(**kwargs: Any) -> Any:
+            if pull_exception is not None:
+                if not isinstance(pull_exception, list):
+                    raise pull_exception
+                else:
+                    exc = pull_exception.pop(0)
+                    if exc is not None:
+                        raise exc
+            return message_queue
+
+        mock_pull = AsyncMock()
+        mock_pull.side_effect = pull_result
+        mock.return_value.streaming_pull = mock_pull
+        mock.return_value.acknowledge = AsyncMock()
+        yield mock
+
+
+@pytest.fixture(name="messages_received")
+def messages_received() -> list[Message]:
+    """Fixture to allow tests to add messages to the pubsub feed."""
+    return []
+
+
+@pytest.fixture(name="factory")
+def mock_streaming_manager_factory(
+    subscriber_async_client: Mock,
+    auth_client: Callable[[], Awaitable[AbstractAuth]],
+    messages_received: list[Message],
+    callback_exception: Exception | None,
+) -> Generator[Callable[[], Awaitable[StreamingManager]], None, None]:
+
+    async def create() -> StreamingManager:
+        auth = await auth_client()
+
+        async def callback(message: Message) -> None:
+            if callback_exception:
+                raise callback_exception
+            _LOGGER.debug("Received message %s", message)
+            messages_received.append(message)
+
+        return StreamingManager(auth, SUBSCRIPTION_NAME, callback)
+
+    with patch(
+        "google_nest_sdm.streaming_manager.MIN_BACKOFF_INTERVAL",
+        datetime.timedelta(seconds=0),
+    ):
+        yield create
+
+
+async def test_subscribe_no_events(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+) -> None:
+    streaming_manager = await factory()
+    await streaming_manager.start()
+    streaming_manager.stop()
+
+
+async def test_events_received_at_start(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+    messages_received: list[Message],
+) -> None:
+    streaming_manager = await factory()
+
+    await message_queue.async_push_events(
+        [
+            {"eventId": "1"},
+            {"eventId": "2"},
+        ]
+    )
+    await streaming_manager.start()
+    await asyncio.sleep(0)  # yield to background task
+
+    assert len(messages_received) == 2
+    assert messages_received[0].payload == {"eventId": "1"}
+    assert messages_received[1].payload == {"eventId": "2"}
+    streaming_manager.stop()
+
+
+async def test_events_received_after_start(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+    messages_received: list[Message],
+) -> None:
+    streaming_manager = await factory()
+    await streaming_manager.start()
+
+    await message_queue.async_push_events([{"eventId": "1"}])
+
+    assert len(messages_received) == 1
+    assert messages_received[0].payload == {"eventId": "1"}
+    streaming_manager.stop()
+
+
+async def test_cancel_after_message_received(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+    messages_received: list[Message],
+) -> None:
+    streaming_manager = await factory()
+    await streaming_manager.start()
+
+    await message_queue.async_push_events([{"eventId": "1"}], sleep=False)
+    streaming_manager.stop()
+    await asyncio.sleep(0)
+
+    assert len(messages_received) == 0
+    streaming_manager.stop()
+
+
+@pytest.mark.parametrize(
+    ("pull_exception", "expected", "metrics"),
+    [
+        (
+            Unauthenticated("Error"),  # type: ignore[no-untyped-call]
+            AuthException,
+            {"streaming_pull.unauthenticated": 1},
+        ),
+        (
+            GoogleAPIError("Error"),  # type: ignore[no-untyped-call]
+            SubscriberException,
+            {"streaming_pull.api_error": 1},
+        ),
+        (
+            ClientError("Error"),  # type: ignore[no-untyped-call]
+            SubscriberException,
+            {"streaming_pull.api_error": 1},
+        ),
+    ],
+)
+async def test_start_exception(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+    expected: type[Exception],
+    metrics: dict[str, int],
+) -> None:
+    streaming_manager = await factory()
+
+    with pytest.raises(expected):
+        await streaming_manager.start()
+
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "connect": 1,
+                "start": 1,
+            },
+            "subscriber": {
+                **metrics,
+            },
+        },
+    )
+
+    streaming_manager.stop()
+
+
+async def test_run_loop_exception(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+    messages_received: list[Message],
+) -> None:
+    streaming_manager = await factory()
+    await message_queue.async_push_errors([AuthException()])
+
+    await streaming_manager.start()
+    await asyncio.sleep(0)  # yield to background task
+
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "exception": 1,
+                "connect": 2,
+                "run": 1,
+                "start": 1,
+            }
+        },
+    )
+
+    streaming_manager.stop()
+
+
+@pytest.mark.parametrize(
+    ("callback_exception", "metrics"),
+    [
+        (AuthException(), {"process_message_exception": 1}),
+        (TimeoutError(), {"process_message_timeout": 1}),
+    ],
+)
+async def test_callback_exception(
+    device_handler: DeviceHandler,
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+    messages_received: list[Message],
+    metrics: dict[str, int],
+) -> None:
+    streaming_manager = await factory()
+    await message_queue.async_push_events([{"eventId": "1"}])
+
+    await streaming_manager.start()
+    await asyncio.sleep(0)  # yield to background task
+
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "connect": 1,
+                "run": 1,
+                "start": 1,
+                "process_message": 1,
+                **metrics,
+            }
+        },
+    )
+
+    streaming_manager.stop()
+
+
+@pytest.mark.parametrize(
+    ("pull_exception"),
+    [
+        ([None, GoogleAPIError("Error"), None]),
+    ],
+)
+async def test_reconnect_exception(
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+    messages_received: list[Message],
+) -> None:
+    streaming_manager = await factory()
+
+    await streaming_manager.start()
+    await message_queue.async_push_events([{"eventId": "1"}])
+
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "connect": 1,
+                "run": 1,
+                "start": 1,
+                "process_message": 1,
+            }
+        },
+    )
+
+    # Fail the active streaming pull. The next attempt to connect will also
+    # fail because of the pull_exceptiopn fixture above.
+    await message_queue.async_push_errors([SubscriberException("Error")])
+
+    # Track next attempt to connect
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "backoff": 1,
+                "connect": 2,
+                "exception": 1,
+                "run": 1,
+                "start": 1,
+                "process_message": 1,
+            },
+            "subscriber": {
+                "streaming_pull.api_error": 1,
+            },
+        },
+    )
+
+    # Verify that new messages can be processed after reconnect
+    await message_queue.async_push_events([{"eventId": "2"}])
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "backoff": 1,
+                "connect": 3,
+                "exception": 1,
+                "run": 1,
+                "start": 1,
+                "process_message": 2,
+            },
+            "subscriber": {
+                "streaming_pull.api_error": 1,
+            },
+        },
+    )
+
+    streaming_manager.stop()
+
+    assert len(messages_received) == 2
+    assert messages_received[0].payload == {"eventId": "1"}
+    assert messages_received[1].payload == {"eventId": "2"}
+
+
+async def test_uncaught_streaming_pull_exception(
+    factory: Callable[[], Awaitable[StreamingManager]],
+    message_queue: MessageQueue,
+) -> None:
+    streaming_manager = await factory()
+
+    await streaming_manager.start()
+    await message_queue.async_push_errors([Exception("Error")])
+
+    assert_diagnostics(
+        diagnostics.get_diagnostics(),
+        {
+            "streaming_manager": {
+                "connect": 1,
+                "run": 1,
+                "start": 1,
+                "uncaught_exception": 1,
+            }
+        },
+    )
+
+    streaming_manager.stop()

--- a/tests/test_subscriber_client.py
+++ b/tests/test_subscriber_client.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock, AsyncMock, patch
+
+import pytest
+from google.auth.exceptions import RefreshError, GoogleAuthError, TransportError
+from google.api_core.exceptions import GoogleAPIError, NotFound, Unauthenticated
+
+from google_nest_sdm.exceptions import (
+    AuthException,
+    SubscriberException,
+    ConfigurationException,
+)
+from google_nest_sdm.subscriber_client import (
+    refresh_creds,
+    SubscriberClient,
+)
+
+
+async def test_refresh_creds() -> None:
+    """Test low level refresh errors."""
+    mock_refresh = Mock()
+    mock_creds = Mock()
+    mock_creds.refresh = mock_refresh
+    refresh_creds(mock_creds)
+    assert mock_refresh.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        (RefreshError(), AuthException),
+        (TransportError(), SubscriberException),
+        (GoogleAuthError(), SubscriberException),
+    ],
+)
+async def test_refresh_creds_error(raised: Exception, expected: Any) -> None:
+    """Test low level refresh errors."""
+    mock_refresh = Mock()
+    mock_refresh.side_effect = raised
+    mock_creds = Mock()
+    mock_creds.refresh = mock_refresh
+    with pytest.raises(expected):
+        refresh_creds(mock_creds)
+
+
+async def test_ack_no_messages() -> None:
+    """Test ack with no messages to ack is a no-op."""
+
+    client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
+    await client.ack_messages([])
+
+
+async def test_ack_messages() -> None:
+    """Test ack messages."""
+
+    client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
+    with patch("google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient") as mock_client:
+        mock_acknowledge = AsyncMock()
+        mock_acknowledge.return_value = None
+        mock_client.return_value.acknowledge = mock_acknowledge
+        await client.ack_messages(["message1", "message2"])
+
+    # Verify that acknowledge was called with the correct arguments
+    mock_acknowledge.assert_awaited_once_with(
+        subscription="test",
+        ack_ids=["message1", "message2"]
+    )
+
+
+async def test_streaming_pull() -> None:
+    """Test ack messages."""
+
+    client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
+    with patch("google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient") as mock_client:
+        mock_streaming_pull = AsyncMock()
+        mock_streaming_pull.return_value = None
+        mock_client.return_value.streaming_pull = mock_streaming_pull
+        await client.streaming_pull()
+
+    # Verify the call was invoked with the correct arguments
+    mock_streaming_pull.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected", "message"),
+    [
+        (NotFound("my error"), ConfigurationException, "NotFound error"),
+        (GoogleAPIError("my error"), SubscriberException, "API error"),
+        (Exception(), SubscriberException, "Unexpected error"),
+    ],
+)
+async def test_streaming_pull_failure(
+    raised: Exception, expected: Any, message: str
+) -> None:
+    """Test ack messages."""
+
+    client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
+    with patch("google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient") as mock_client:
+        mock_streaming_pull = AsyncMock()
+        mock_streaming_pull.side_effect = raised
+        mock_client.return_value.streaming_pull = mock_streaming_pull
+
+        with pytest.raises(expected, match=message):
+            await client.streaming_pull()

--- a/tests/test_subscriber_client.py
+++ b/tests/test_subscriber_client.py
@@ -86,9 +86,10 @@ async def test_streaming_pull() -> None:
 @pytest.mark.parametrize(
     ("raised", "expected", "message"),
     [
-        (NotFound("my error"), ConfigurationException, "NotFound error"),
-        (GoogleAPIError("my error"), SubscriberException, "API error"),
-        (Exception(), SubscriberException, "Unexpected error"),
+        (NotFound("my error"), ConfigurationException, "NotFound error calling streaming_pull: 404 my error"),
+        (GoogleAPIError("my error"), SubscriberException, "API error when calling streaming_pull: my error"),
+        (Unauthenticated("auth error"), AuthException, "Failed to authenticate streaming_pull: 401 auth error"),
+        (Exception("my error"), SubscriberException, "Unexpected error when calling streaming_pull: my error"),
     ],
 )
 async def test_streaming_pull_failure(

--- a/tests/test_subscriber_client.py
+++ b/tests/test_subscriber_client.py
@@ -56,7 +56,9 @@ async def test_ack_messages() -> None:
     """Test ack messages."""
 
     client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
-    with patch("google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient") as mock_client:
+    with patch(
+        "google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient"
+    ) as mock_client:
         mock_acknowledge = AsyncMock()
         mock_acknowledge.return_value = None
         mock_client.return_value.acknowledge = mock_acknowledge
@@ -64,8 +66,7 @@ async def test_ack_messages() -> None:
 
     # Verify that acknowledge was called with the correct arguments
     mock_acknowledge.assert_awaited_once_with(
-        subscription="test",
-        ack_ids=["message1", "message2"]
+        subscription="test", ack_ids=["message1", "message2"]
     )
 
 
@@ -73,7 +74,9 @@ async def test_streaming_pull() -> None:
     """Test ack messages."""
 
     client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
-    with patch("google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient") as mock_client:
+    with patch(
+        "google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient"
+    ) as mock_client:
         mock_streaming_pull = AsyncMock()
         mock_streaming_pull.return_value = None
         mock_client.return_value.streaming_pull = mock_streaming_pull
@@ -86,10 +89,26 @@ async def test_streaming_pull() -> None:
 @pytest.mark.parametrize(
     ("raised", "expected", "message"),
     [
-        (NotFound("my error"), ConfigurationException, "NotFound error calling streaming_pull: 404 my error"),
-        (GoogleAPIError("my error"), SubscriberException, "API error when calling streaming_pull: my error"),
-        (Unauthenticated("auth error"), AuthException, "Failed to authenticate streaming_pull: 401 auth error"),
-        (Exception("my error"), SubscriberException, "Unexpected error when calling streaming_pull: my error"),
+        (
+            NotFound("my error"),  # type: ignore[no-untyped-call]
+            ConfigurationException,
+            "NotFound error calling streaming_pull: 404 my error",
+        ),
+        (
+            GoogleAPIError("my error"),
+            SubscriberException,
+            "API error when calling streaming_pull: my error",
+        ),
+        (
+            Unauthenticated("auth error"),  # type: ignore[no-untyped-call]
+            AuthException,
+            "Failed to authenticate streaming_pull: 401 auth error",
+        ),
+        (
+            Exception("my error"),
+            SubscriberException,
+            "Unexpected error when calling streaming_pull: my error",
+        ),
     ],
 )
 async def test_streaming_pull_failure(
@@ -98,7 +117,9 @@ async def test_streaming_pull_failure(
     """Test ack messages."""
 
     client = SubscriberClient(auth=AsyncMock(), subscription_name="test")
-    with patch("google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient") as mock_client:
+    with patch(
+        "google_nest_sdm.subscriber_client.pubsub_v1.SubscriberAsyncClient"
+    ) as mock_client:
         mock_streaming_pull = AsyncMock()
         mock_streaming_pull.side_effect = raised
         mock_client.return_value.streaming_pull = mock_streaming_pull


### PR DESCRIPTION
This is a rewrite of the Nest pub/sub subscription code to use the async interfaces. 

# Breaking changes

The constructor and start/stop calls have been changed and changes are required

To migrate to the new API:
- Remove the topic constructor argument as other health related metrics like the watchdog
- The return value to `start_async` now returns a `Callable` that us used to stop the subscription
- The `stop_async` method has been removed