### PR TITLE
Add API method for setting an IAM policy

### DIFF
--- a/google_nest_sdm/admin_client.py
+++ b/google_nest_sdm/admin_client.py
@@ -60,6 +60,18 @@ class EligibleSubscriptions:
 
     subscription_names: list[str] = field(default_factory=list)
 
+# Policy that gives Device Access Console permission to publish to a topic
+DEFAULT_TOPIC_IAM_POLICY = {
+    "bindings": [
+        {
+            "members": [
+                "group:sdm-publisher@googlegroups.com"
+            ],
+            "role": "roles/pubsub.publisher"
+        }
+    ]
+}
+
 
 def validate_subscription_name(subscription_name: str) -> None:
     """Validates that a subscription name is correct.
@@ -144,6 +156,16 @@ class AdminClient:
         """Get a pubsub topic for the project."""
         validate_topic_name(topic_name)
         return await self._auth.get_json(topic_name)
+
+    async def set_topic_iam_policy(self, topic_name: str, policy: dict[str, Any]) -> None:
+        """Create a pubsub topic for the project."""
+        validate_topic_name(topic_name)
+        path = f"{topic_name}:setIamPolicy"
+        await self._auth.post(
+            path,
+            json={"policy":policy}
+        )
+
 
     async def create_subscription(
         self, topic_name: str, subscription_name: str

--- a/tests/test_admin_client.py
+++ b/tests/test_admin_client.py
@@ -530,3 +530,28 @@ async def test_list_eligible_subscriptions(
     assert eligible_subscriptions.subscription_names == [
         f"projects/{GOOGLE_CLOUD_CONSOLE_PROJECT_ID}/subscriptions/sdm-testing-sub",
     ]
+
+
+
+async def test_set_topic_iam_policy(
+    app: aiohttp.web.Application,
+    admin_client: Callable[[], Awaitable[AdminClient]],
+    recorder: Recorder,
+) -> None:
+    """Test setting an IAM policy on a topic."""
+
+    handler = NewHandler(
+        recorder,
+        [{}],
+    )
+    app.router.add_post(
+        f"/projects/{GOOGLE_CLOUD_CONSOLE_PROJECT_ID}/topics/topic-name:setIamPolicy", handler
+    )
+
+    client = await admin_client()
+    await client.set_topic_iam_policy(
+        f"projects/{GOOGLE_CLOUD_CONSOLE_PROJECT_ID}/topics/topic-name",
+        {"bindings": [{"role": "roles/pubsub.publisher", "members": ["user:foo"]}]},
+    )
+
+    assert recorder.request == {"policy": {"bindings": [{"role": "roles/pubsub.publisher", "members": ["user:foo"]}]}}


### PR DESCRIPTION
This is needed to automatically set up pubsub topics.